### PR TITLE
Load modpack info after LaunchFrame is created

### DIFF
--- a/src/net/ftb/gui/LaunchFrame.java
+++ b/src/net/ftb/gui/LaunchFrame.java
@@ -309,12 +309,6 @@ public class LaunchFrame extends JFrame {
 //		splash.setIcon(new ImageIcon(ModPack.getPack(0).getImage()));
 		modPacksPane.add(splash);
 
-		try {
-			ModPack.LoadAll();
-		} catch (NoSuchAlgorithmException e) {
-			e.printStackTrace();
-		}
-
 		EventQueue.invokeLater(new Runnable() {
 			public void run() {
 				initialiseModpacks(tab);
@@ -323,6 +317,12 @@ public class LaunchFrame extends JFrame {
 	}
 
 	public void initialiseModpacks(int tab){
+		try {
+			ModPack.LoadAll();
+		} catch (NoSuchAlgorithmException e) {
+			e.printStackTrace();
+		}
+
 		packPanels = new JPanel[ModPack.getPackArray().size()];
 		for(int i = 0; i < packPanels.length; i++) {
 			final int packIndex = i;


### PR DESCRIPTION
The previous fix delayed the loading of the images, but did not delay loading the rest of the modpack info.

Signed-off-by: Ross Allan rallanpcl@gmail.com
