### PR TITLE
Fixes for issues found via static analysis and pom fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,20 @@
   <version>0.1.2-Beta</version>
   <packaging>jar</packaging>
   <properties>
-    <buildNumber>012</buildNumber>
+    <buildNumber>0</buildNumber> <!-- This will be set by the CI (eg: jenkins, or FTB_Bot)-->
     <mainClass>net.ftb.gui.LaunchFrame</mainClass>
     <minimumJreVersion>1.6</minimumJreVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <exeVersionNumber>0.1.2.${buildNumber}</exeVersionNumber> <!-- Must be of the form x.x.x.x -->
   </properties>
 
   <name>FTB Launcher</name>
   <url>https://github.com/Slowpoke101/FTBLaunch</url>
+
+  <organization>
+    <name>FTB Launcher Contributors</name>
+    <url>https://github.com/Slowpoke101/FTBLaunch</url>
+  </organization>
 
   <build>
     <defaultGoal>clean install package</defaultGoal>
@@ -72,15 +78,15 @@
               </jre>
               <icon>${basedir}/res/image/logo_ftb.ico</icon>
               <versionInfo>
-                <fileVersion>2.0.0.${buildNumber}</fileVersion>
-                <txtFileVersion>2.0.0.${buildNumber}</txtFileVersion>
-                <productVersion>2.0.0.${buildNumber}</productVersion>
-                <txtProductVersion>2.0.0.${buildNumber}</txtProductVersion>
+                <fileVersion>${exeVersionNumber}</fileVersion>
+                <txtFileVersion>${exeVersionNumber}</txtFileVersion>
+                <productVersion>${exeVersionNumber}</productVersion>
+                <txtProductVersion>${exeVersionNumber}</txtProductVersion>
                 <fileDescription>${project.name}</fileDescription>
                 <productName>${project.name}</productName>
                 <copyright>${project.organization.name}, ${project.organization.url}</copyright>
                 <internalName>${project.artifactId}</internalName>
-                <originalFilename>${project.artifactId}.exe</originalFilename>
+                <originalFilename>${project.artifactId}-${project.version}.exe</originalFilename>
               </versionInfo>
             </configuration>
             <phase>package</phase>

--- a/src/net/ftb/data/ModPack.java
+++ b/src/net/ftb/data/ModPack.java
@@ -22,24 +22,24 @@ import net.ftb.gui.LaunchFrame;
 import net.ftb.workers.ModpackLoader;
 
 public class ModPack {	
-	private String name;
-	private String author;
-	private String version;
+	private final String name;
+	private final String author;
+	private final String version;
 	private Image logo;
-	private String url;
+	private final String url;
 	private Image image;
-	private String dir;
-	private String mcVersion;
-	private String info = "This is the info until there is an actual info thingy";
+	private final String dir;
+	private final String mcVersion;
+	private final String info = "This is the info until there is an actual info thingy";
 	private int size;
-	private String serverUrl;
+	private final String serverUrl;
 
-	private static ArrayList<ModPack> packs = new ArrayList<ModPack>();
+	private static final ArrayList<ModPack> packs = new ArrayList<ModPack>();
 
 	/*
 	 * List of Listeners that will be informed if a modpack was added
 	 */
-	private static List<ModPackListener> listeners = new ArrayList<ModPackListener>();
+	private static final List<ModPackListener> listeners = new ArrayList<ModPackListener>();
 
 	/*
 	 * Invoking async Load of Modpacks

--- a/src/net/ftb/data/Settings.java
+++ b/src/net/ftb/data/Settings.java
@@ -28,7 +28,7 @@ public class Settings extends Properties {
 		settings.setConfigFile(cfgFile);
 	}
 
-	public static void LoadSettings(File file) throws FileNotFoundException, IOException {
+	public static void LoadSettings(File file) throws IOException {
 		settings = new Settings(file);
 	}
 
@@ -38,12 +38,12 @@ public class Settings extends Properties {
 
 	public Settings() { }
 
-	public Settings(File file) throws FileNotFoundException, IOException {
+	public Settings(File file) throws IOException {
 		configPath = file;
 		load(new FileInputStream(file));
 	}
 
-	public void save() throws FileNotFoundException, IOException {
+	public void save() throws IOException {
 		store(new FileOutputStream(configPath), "FTBLaunch Config File");
 	}
 

--- a/src/net/ftb/data/UserManager.java
+++ b/src/net/ftb/data/UserManager.java
@@ -15,16 +15,14 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 
 public class UserManager {
-	public static ArrayList<User> _users = new ArrayList<User>();
+	public static final ArrayList<User> _users = new ArrayList<User>();
 
-	private File _filename;
+	private final File _filename;
 
 	public UserManager(File filename) {
 		_filename = filename;
 		if (_filename.exists()) {
-			try {
-				read();
-			} catch (IOException e) { }
+			read();
 		}
 	}
 
@@ -86,7 +84,7 @@ public class UserManager {
 		wri.close();
  	}
  	
- 	public void read() throws IOException {
+ 	public void read(){
  		_users.clear();
  		
  		if(_filename.exists()) {
@@ -107,7 +105,7 @@ public class UserManager {
  	}
 
 	
-	public static byte[] getFileMD5(URL string) throws Exception {
+	public static byte[] getFileMD5(URL string) throws IOException{
 		MessageDigest dgest = null;
 		try {
 			dgest = MessageDigest.getInstance("md5");
@@ -117,7 +115,7 @@ public class UserManager {
 		InputStream str = string.openStream();
 
 		byte[] buffer = new byte[65536];
-		int readLen = 0;
+		int readLen;
 		while ((readLen = str.read(buffer, 0, buffer.length)) != -1) {
 			dgest.update(buffer, 0, readLen);
 		}
@@ -155,7 +153,7 @@ public class UserManager {
 
 	public static String getUsername(String name) {
 		for (User user : _users) {
-			if (user.getName() == name) {
+			if (user.getName().equals(name)) {
 				return user.getUsername();
 			}
 		}
@@ -164,7 +162,7 @@ public class UserManager {
 
 	public static String getPassword(String name) {
 		for (User user : _users) {
-			if (user.getName() == name) {
+			if (user.getName().equals(name)) {
 				return user.getPassword();
 			}
 		}

--- a/src/net/ftb/gui/ChooseDir.java
+++ b/src/net/ftb/gui/ChooseDir.java
@@ -15,10 +15,8 @@ import net.ftb.gui.panes.OptionsPane;
 public class ChooseDir extends JFrame implements ActionListener {
 	private static final long serialVersionUID = 1L;
 
-	private OptionsPane optionsPane;
+	private final OptionsPane optionsPane;
 	private JButton go;
-
-	private JFileChooser chooser;
 	private String choosertitle;
 
 	public ChooseDir(OptionsPane optionsPane) {
@@ -26,8 +24,9 @@ public class ChooseDir extends JFrame implements ActionListener {
 		this.optionsPane = optionsPane;
 	}
 
+	@Override
 	public void actionPerformed(ActionEvent e) {
-		chooser = new JFileChooser();
+		JFileChooser chooser = new JFileChooser();
 		chooser.setCurrentDirectory(new java.io.File(optionsPane.getInstallFolderText()));
 		chooser.setDialogTitle(choosertitle);
 		chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
@@ -42,6 +41,7 @@ public class ChooseDir extends JFrame implements ActionListener {
 		}
 	}
 
+	@Override
 	public Dimension getPreferredSize() {
 		return new Dimension(200, 200);
 	}
@@ -50,6 +50,7 @@ public class ChooseDir extends JFrame implements ActionListener {
 		JFrame frame = new JFrame("");
 		ChooseDir panel = new ChooseDir(new OptionsPane());
 		frame.addWindowListener(new WindowAdapter() {
+			@Override
 			public void windowClosing(WindowEvent e) {
 				System.exit(0);
 			}

--- a/src/net/ftb/gui/JRoundPasswordField.java
+++ b/src/net/ftb/gui/JRoundPasswordField.java
@@ -16,17 +16,20 @@ public class JRoundPasswordField extends JPasswordField {
 		setOpaque(false);
 	}
 
+	@Override
 	protected void paintComponent(Graphics g) {
 		g.setColor(getBackground());
 		g.fillRoundRect(0, 0, getWidth()-1, getHeight()-1, 20, 20);
 		super.paintComponent(g);
 	}
 
+	@Override
 	protected void paintBorder(Graphics g) {
 		g.setColor(Color.white);
 		g.drawRoundRect(0, 0, getWidth()-1, getHeight()-1, 20, 20);
 	}
 
+	@Override
 	public boolean contains(int x, int y) {
 		if (shape == null || !shape.getBounds().equals(getBounds())) {
 			shape = new RoundRectangle2D.Float(0, 0, getWidth()-1, getHeight()-1, 15, 15);

--- a/src/net/ftb/gui/JRoundTextField.java
+++ b/src/net/ftb/gui/JRoundTextField.java
@@ -16,17 +16,20 @@ public class JRoundTextField extends JTextField {
 		setOpaque(false);
 	}
 
+	@Override
 	protected void paintComponent(Graphics g) {
 		g.setColor(getBackground());
 		g.fillRoundRect(0, 0, getWidth()-1, getHeight()-1, 20, 20);
 		super.paintComponent(g);
 	}
 
+	@Override
 	protected void paintBorder(Graphics g) {
 		g.setColor(Color.white);
 		g.drawRoundRect(0, 0, getWidth()-1, getHeight()-1, 20, 20);
 	}
 
+	@Override
 	public boolean contains(int x, int y) {
 		if (shape == null || !shape.getBounds().equals(getBounds())) {
 			shape = new RoundRectangle2D.Float(0, 0, getWidth()-1, getHeight()-1, 15, 15);

--- a/src/net/ftb/gui/LaunchFrame.java
+++ b/src/net/ftb/gui/LaunchFrame.java
@@ -32,6 +32,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.concurrent.CancellationException;
@@ -49,6 +50,7 @@ import javax.swing.ProgressMonitor;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.WindowConstants;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -72,11 +74,11 @@ public class LaunchFrame extends JFrame {
 	/**
 	 * the panels to appear in the tabs
 	 */
-	private NewsPane newsPane;
-	private OptionsPane optionsPane;
-	private ModpacksPane modPacksPane;
-	private JPanel mapsPane;
-	private JPanel tpPane;
+	private final NewsPane newsPane;
+	private final OptionsPane optionsPane;
+	private final ModpacksPane modPacksPane;
+	private final JPanel mapsPane;
+	private final JPanel tpPane;
 
 	/**
 	 * an array of all mods to be added to classpath
@@ -86,21 +88,21 @@ public class LaunchFrame extends JFrame {
 	/**
 	 * the panel that contains the footer and the tabbed pane
 	 */
-	private JPanel panel = new JPanel();
+	private final JPanel panel = new JPanel();
 
 	/**
 	 * tabbedpane and footer
 	 */
 	private final JTabbedPane tabbedPane = new JTabbedPane(JTabbedPane.TOP);
-	private JPanel footer = new JPanel();
+	private final JPanel footer = new JPanel();
 
 	/**
 	 * the things to go on the footer
 	 */
-	private JLabel footerLogo = new JLabel(new ImageIcon(this.getClass().getResource("/image/logo_ftb.png")));
-	private JLabel footerCreeper = new JLabel(new ImageIcon(this.getClass().getResource("/image/logo_creeperHost.png")));
-	private JButton launch = new JButton("Launch");
-	private static String[] dropdown_ = {"Select Username", "Create Username"};
+	private final JLabel footerLogo = new JLabel(new ImageIcon(this.getClass().getResource("/image/logo_ftb.png")));
+	private final JLabel footerCreeper = new JLabel(new ImageIcon(this.getClass().getResource("/image/logo_creeperHost.png")));
+	private final JButton launch = new JButton("Launch");
+	private static final String[] dropdown_ = {"Select Username", "Create Username"};
 	private static JComboBox users;
 	private JButton edit;
 
@@ -115,7 +117,7 @@ public class LaunchFrame extends JFrame {
 	/**
 	 * random crap
 	 */
-	private static final int version = 012;
+	private static final int version = 12;
 	private URLClassLoader cl;
 	private FileOutputStream fos;
 	private static final long serialVersionUID = 1L;
@@ -126,10 +128,11 @@ public class LaunchFrame extends JFrame {
 
 	/**
 	 * Launch the application.
-	 * @param args
+	 * @param args CLI arguments
 	 */
 	public static void main(String[] args) {
 		EventQueue.invokeLater(new Runnable() {
+			@Override
 			public void run() {
 				Color baseColor = new Color(40, 40, 40);
 
@@ -151,10 +154,10 @@ public class LaunchFrame extends JFrame {
 				} catch (Exception e) {
 					try {
 						UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
-					} catch (ClassNotFoundException e1) { }
-					catch (InstantiationException e1) { }
-					catch (IllegalAccessException e1) { }
-					catch (UnsupportedLookAndFeelException e1) { }
+					} catch (ClassNotFoundException ignored) { }
+					catch (InstantiationException ignored) { }
+					catch (IllegalAccessException ignored) { }
+					catch (UnsupportedLookAndFeelException ignored) { }
 				}
 
 				// Load settings
@@ -173,10 +176,9 @@ public class LaunchFrame extends JFrame {
 
 				userManager = new UserManager(new File(installDir, "logindata"));
 
-				try {
-					LauncherConsole con = new LauncherConsole();
-					con.setVisible(true);
-				} catch (IOException e) { e.printStackTrace(); }
+				LauncherConsole con = new LauncherConsole();
+				con.setVisible(true);
+
 				LaunchFrame frame = new LaunchFrame(2);
 				instance = frame;
 				frame.setVisible(true);
@@ -196,7 +198,7 @@ public class LaunchFrame extends JFrame {
 		setTitle("Feed the Beast Launcher Beta v0.1.2");
 		setIconImage(Toolkit.getDefaultToolkit().getImage(this.getClass().getResource("/image/logo_ftb.png")));
 
-		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 		setBounds(100, 100, 850, 480);
 		panel.setBounds(0, 0, 850, 480);
 		panel.setLayout(null);
@@ -211,17 +213,31 @@ public class LaunchFrame extends JFrame {
 		//Footer
 		footerLogo.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 		footerLogo.setBounds(20, 20, 42, 42);
-		footerLogo.addMouseListener(new MouseListener() {
-			@Override 
-			public void mouseClicked(MouseEvent event) {
-				try {
+		footerLogo.addMouseListener(new MouseListener(){
+			@Override
+			public void mouseClicked(MouseEvent event){
+				try{
 					Hlink(event, new URI("http://www.feed-the-beast.com"));
-				} catch (URISyntaxException e) { e.printStackTrace(); }
+				}catch(URISyntaxException e){
+					e.printStackTrace();
+				}
 			}
-			@Override public void mouseReleased(MouseEvent arg0) { }
-			@Override public void mousePressed(MouseEvent arg0) { }
-			@Override public void mouseExited(MouseEvent arg0) { }
-			@Override public void mouseEntered(MouseEvent arg0) { }
+
+			@Override
+			public void mouseReleased(MouseEvent arg0){
+			}
+
+			@Override
+			public void mousePressed(MouseEvent arg0){
+			}
+
+			@Override
+			public void mouseExited(MouseEvent arg0){
+			}
+
+			@Override
+			public void mouseEntered(MouseEvent arg0){
+			}
 		});
 		
 		footerCreeper.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
@@ -239,11 +255,10 @@ public class LaunchFrame extends JFrame {
 			@Override public void mouseEntered(MouseEvent arg0) { }
 		});
 
-		try {
-			userManager.read();
-		} catch (IOException e1) { e1.printStackTrace(); }
+		userManager.read();
 
-		String[] dropdown = merge(dropdown_, UserManager.getNames().toArray(new String[] {}));
+		ArrayList<String> var = UserManager.getNames();
+		String[] dropdown = merge(dropdown_, var.toArray(new String[var.size()]));
 		users = new JComboBox(dropdown);
 		if(Settings.getSettings().getLastUser() != null) {
 			for(int i = 0; i < dropdown.length; i++) {
@@ -288,7 +303,7 @@ public class LaunchFrame extends JFrame {
 			public void actionPerformed(ActionEvent arg0) {
 				if(users.getSelectedIndex() > 1) {
 					saveSettings();
-					doLogin(userManager.getUsername(users.getSelectedItem().toString()), userManager.getPassword(users.getSelectedItem().toString()));
+					doLogin(UserManager.getUsername(users.getSelectedItem().toString()), UserManager.getPassword(users.getSelectedItem().toString()));
 				}
 			}
 		});
@@ -408,10 +423,11 @@ public class LaunchFrame extends JFrame {
 			final ProgressMonitor progMonitor = new ProgressMonitor(this, "Downloading minecraft...", "", 0, 100);
 			final GameUpdateWorker updater = new GameUpdateWorker(RESPONSE.getLatestVersion(), "minecraft.jar", 
 					new File(Settings.getSettings().getInstallPath(), ".minecraft//bin").getPath(), false) {
+				@Override
 				public void done() {
 					progMonitor.close();
 					try {
-						if (get() == true) {
+						if (get()) {
 							// Success
 							System.out.println("Game update complete.");
 
@@ -441,7 +457,6 @@ public class LaunchFrame extends JFrame {
 					} catch (ExecutionException e) {
 						e.printStackTrace();
 						System.out.println("Failed to download game: " + e.getCause().getMessage());
-						return;
 					}
 				}
 			};
@@ -533,7 +548,7 @@ public class LaunchFrame extends JFrame {
 	 * @throws MalformedURLException - for URL
 	 * @throws IOException - various
 	 */
-	public void downloadUrl(String filename, String urlString) throws MalformedURLException, IOException {
+	public void downloadUrl(String filename, String urlString) throws IOException {
 		BufferedInputStream in = null;
 		FileOutputStream fout = null;
 		try {
@@ -561,7 +576,6 @@ public class LaunchFrame extends JFrame {
 	 * @param workingDir - install path
 	 * @param username - the MC username
 	 * @param password - the MC password
-	 * @throws IOException
 	 */
 	protected void launchMinecraft(String workingDir, String username, String password) {
 		try {
@@ -594,13 +608,12 @@ public class LaunchFrame extends JFrame {
 			Class<?> mc = cl.loadClass("net.minecraft.client.Minecraft");
 			Field[] fields = mc.getDeclaredFields();
 
-			for (int i = 0; i < fields.length; i++) {
-				Field f = fields[i];
-				if (f.getType() != File.class) {
+			for(Field f : fields){
+				if(f.getType() != File.class){
 					// Has to be File
 					continue;
 				}
-				if (f.getModifiers() != (Modifier.PRIVATE + Modifier.STATIC)) {
+				if(0 == (f.getModifiers() & (Modifier.PRIVATE | Modifier.STATIC))){
 					// And Private Static.
 					continue;
 				}
@@ -662,13 +675,13 @@ public class LaunchFrame extends JFrame {
 		new File(Settings.getSettings().getInstallPath() + "/" + ModPack.getPack(modPacksPane.getSelectedModIndex()).getDir() + "/.minecraft/coremods").delete();
 	 	File[] contents = new File(Settings.getSettings().getInstallPath() + "/" + ModPack.getPack(modPacksPane.getSelectedModIndex()).getDir() + "/.minecraft/bin/").listFiles();
 		String files;
-		for (int i = 0; i < contents.length; i++) {             
-			if (contents[i].isFile()) {
-				files = contents[i].getName();
-				if (files.endsWith(".zip") || files.endsWith(".ZIP")) {
-					contents[i].delete();
+		for(File content : contents){
+			if(content.isFile()){
+				files = content.getName();
+				if(files.endsWith(".zip") || files.endsWith(".ZIP")){
+					content.delete();
 				}
-			}	
+			}
 		}
 	}
 
@@ -724,7 +737,8 @@ public class LaunchFrame extends JFrame {
 		try {
 			userManager.write();
 		} catch (IOException e) { e.printStackTrace(); }
-		String[] usernames = merge(dropdown_, UserManager.getNames().toArray(new String[] {}));;
+		ArrayList<String> var = UserManager.getNames();
+		String[] usernames = merge(dropdown_, var.toArray(new String[var.size()]));
 		users.removeAllItems();
 		for(int i = 0; i < usernames.length; i++){
 			users.addItem(usernames[i]);

--- a/src/net/ftb/gui/LauncherConsole.java
+++ b/src/net/ftb/gui/LauncherConsole.java
@@ -21,12 +21,12 @@ public class LauncherConsole extends JDialog {
 
 	final JTextArea textArea;
 
-	private JScrollPane scrollPane;
+	private final JScrollPane scrollPane;
 
 	private static Boolean logToConsole = true;
 
 	private class OutputOverride extends PrintStream {
-		public OutputOverride(OutputStream str) throws FileNotFoundException {
+		public OutputOverride(OutputStream str){
 			super(str);
 		}
 
@@ -55,7 +55,7 @@ public class LauncherConsole extends JDialog {
 		}
 	}
 
-	public LauncherConsole() throws IOException {
+	public LauncherConsole(){
 		setTitle("FTB Launcher Console");
 		this.setSize(new Dimension(451, 300));
 		setResizable(false);

--- a/src/net/ftb/gui/ModManager.java
+++ b/src/net/ftb/gui/ModManager.java
@@ -1,5 +1,13 @@
 package net.ftb.gui;
 
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JProgressBar;
+import javax.swing.SwingConstants;
+import javax.swing.SwingWorker;
+import javax.swing.border.EmptyBorder;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.io.BufferedInputStream;
@@ -23,15 +31,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JProgressBar;
-import javax.swing.SwingConstants;
-import javax.swing.SwingWorker;
-import javax.swing.border.EmptyBorder;
-
 import net.ftb.data.ModPack;
 import net.ftb.data.Settings;
 import net.ftb.gui.dialogs.UpdateDialog;
@@ -39,33 +38,33 @@ import net.ftb.util.FileUtils;
 
 public class ModManager extends JDialog {
 	private static final long serialVersionUID = 6897832855341265019L;
-
 	public static boolean update = false;
-	
-	private JPanel contentPane;
-
+	private final JPanel contentPane;
 	private double downloadedPerc;
-	private Settings settings = new Settings();	
-
+	private Settings settings = new Settings();
 	private final JProgressBar progressBar;
 	private final JLabel label;
 
 	private class ModManagerWorker extends SwingWorker<Boolean, Void> {
 		@Override
-		protected Boolean doInBackground() throws Exception {
-			if(!upToDate()){
+		protected Boolean doInBackground() throws IOException, NoSuchAlgorithmException {
+			if (!upToDate()) {
 				System.out.println("Not up to date!");
 				String installPath = Settings.getSettings().getInstallPath();
 				ModPack pack = ModPack.getPack(LaunchFrame.getSelectedModIndex());
 				File modPackZip = new File(installPath + "/temp/" + pack.getDir() + "/" + pack.getUrl());
-				if(!modPackZip.exists()) {
+				if (!modPackZip.exists()) {
 					System.out.println("Pack not found, downloading!");
 					try {
-						new File(installPath + "/temp/" + pack.getDir() +  "/").mkdir();
+						new File(installPath + "/temp/" + pack.getDir() + "/").mkdir();
 						downloadModPack(pack.getUrl(), pack.getDir());
-					} catch (MalformedURLException e) { e.printStackTrace();
-					} catch (NoSuchAlgorithmException e) { e.printStackTrace();
-					} catch (IOException e) { e.printStackTrace(); }
+					} catch (MalformedURLException e) {
+						e.printStackTrace();
+					} catch (NoSuchAlgorithmException e) {
+						e.printStackTrace();
+					} catch (IOException e) {
+						e.printStackTrace();
+					}
 				} else {
 					System.out.println("Pack found!");
 					installMods(pack.getUrl(), pack.getDir());
@@ -74,7 +73,7 @@ public class ModManager extends JDialog {
 			return false;
 		}
 
-		public void downloadUrl(String filename, String urlString) throws MalformedURLException, IOException {
+		public void downloadUrl(String filename, String urlString) throws IOException {
 			BufferedInputStream in = null;
 			FileOutputStream fout = null;
 			try {
@@ -89,28 +88,28 @@ public class ModManager extends JDialog {
 				int steps = 0;
 				while ((count = in.read(data, 0, 1024)) != -1) {
 					fout.write(data, 0, count);
-					downloadedPerc += (count*1.0/modPackSize)*100;
+					downloadedPerc += (count * 1.0 / modPackSize) * 100;
 					amount += count;
 					steps++;
 					if (steps > 100) {
 						steps = 0;
-						progressBar.setValue((int)downloadedPerc*100);
-						label.setText(String.valueOf(amount / 1024) + "Kb / " + String.valueOf(modPackSize / 1024) + "Kb");
+						progressBar.setValue((int) downloadedPerc * 100);
+						label.setText(amount / 1024 + "Kb / " + modPackSize / 1024 + "Kb");
 					}
 				}
-			} finally {			
+			} finally {
 				in.close();
-				fout.flush();	
+				fout.flush();
 				fout.close();
 			}
 		}
 
-		public void downloadPack(String dest, String file) throws MalformedURLException, NoSuchAlgorithmException, IOException {
+		public void downloadPack(String dest, String file) throws NoSuchAlgorithmException, IOException {
 			DateFormat sdf = new SimpleDateFormat("ddMMyy");
 			TimeZone zone = TimeZone.getTimeZone("GMT");
 			sdf.setTimeZone(zone);
 			String date = sdf.format(new Date());
-			downloadUrl(dest, "http://repo.creeperhost.net/direct/FTB2/" + md5 ( "mcepoch1" + date ) + "/" + file);
+			downloadUrl(dest, "http://repo.creeperhost.net/direct/FTB2/" + md5("mcepoch1" + date) + "/" + file);
 		}
 
 		protected void downloadModPack(String modPackName, String dir) throws IOException, NoSuchAlgorithmException {
@@ -126,41 +125,43 @@ public class ModManager extends JDialog {
 			installMods(modPackName, dir);
 		}
 
-		protected void installMods(String modPackName, String dir) throws IOException, NoSuchAlgorithmException {
+		protected void installMods(String modPackName, String dir) throws IOException {
 			System.out.println("Installing");
 			String installPath = Settings.getSettings().getInstallPath();
-			new File(installPath + "/"+ dir + "/.minecraft").mkdirs();
-			FileUtils.copyFolder(new File(installPath + "/.minecraft/bin/"), new File(installPath + "/"+ dir+ "/.minecraft/bin"));
+			new File(installPath + "/" + dir + "/.minecraft").mkdirs();
+			FileUtils.copyFolder(new File(installPath + "/.minecraft/bin/"), new File(installPath + "/" + dir + "/.minecraft/bin"));
 			LaunchFrame.jarMods = new String[new File(installPath + "/temp/" + modPackName + "/instMods").listFiles().length];
 			try {
 				FileInputStream fstream = new FileInputStream(installPath + "/temp/" + modPackName + "/modlist");
 				DataInputStream in1 = new DataInputStream(fstream);
 				BufferedReader br = new BufferedReader(new InputStreamReader(in1));
 				String strLine;
-				int i=0;
+				int i = 0;
 				while ((strLine = br.readLine()) != null) {
 					// Print the content on the console
 					LaunchFrame.jarMods[i] = strLine;
-					i++;		
+					i++;
 				}
 				//Close the input stream
 				in1.close();
-			} catch (Exception e) { System.err.println("Error: " + e.getMessage()); }
+			} catch (Exception e) {
+				System.err.println("Error: " + e.getMessage());
+			}
 			LaunchFrame.jarMods = reverse(LaunchFrame.jarMods);
 			FileUtils.copyFile(new File(installPath + "/temp/" + dir + "/version"), new File(installPath + "/" + dir));
-			FileUtils.copyFolder(new File(installPath + "/temp/" + dir + "/instMods"), new File(installPath + "/" + dir +"/.minecraft/bin/"));
-			FileUtils.copyFolder(new File(installPath + "/temp/" + dir + "/.minecraft"), new File(installPath + "/" + dir +"/.minecraft/"));
+			FileUtils.copyFolder(new File(installPath + "/temp/" + dir + "/instMods"), new File(installPath + "/" + dir + "/.minecraft/bin/"));
+			FileUtils.copyFolder(new File(installPath + "/temp/" + dir + "/.minecraft"), new File(installPath + "/" + dir + "/.minecraft/"));
 			// Test cleaning up files
 		}
 
 		public String md5(String input) throws NoSuchAlgorithmException {
 			String result = input;
-			if(input != null) {
+			if (input != null) {
 				MessageDigest md = MessageDigest.getInstance("MD5");
 				md.update(input.getBytes());
 				BigInteger hash = new BigInteger(1, md.digest());
 				result = hash.toString(16);
-				while(result.length() < 32) {
+				while (result.length() < 32) {
 					result = "0" + result;
 				}
 			}
@@ -169,13 +170,12 @@ public class ModManager extends JDialog {
 
 		protected String[] reverse(String[] x) {
 			String buffer[] = new String[x.length];
-			for(int i = 0; i<x.length;i++) {
-				buffer[i] = x[x.length-i-1];
+			for (int i = 0; i < x.length; i++) {
+				buffer[i] = x[x.length - i - 1];
 			}
 			return buffer;
 		}
 	}
-
 
 	/**
 	 * Create the frame.
@@ -217,19 +217,37 @@ public class ModManager extends JDialog {
 				};
 				worker.execute();
 			}
-			@Override public void windowActivated(WindowEvent e) { }
-			@Override public void windowClosed(WindowEvent e) { }
-			@Override public void windowClosing(WindowEvent e) { }
-			@Override public void windowDeactivated(WindowEvent e) { }
-			@Override public void windowDeiconified(WindowEvent e) { }
-			@Override public void windowIconified(WindowEvent e) { }
+
+			@Override
+			public void windowActivated(WindowEvent e) {
+			}
+
+			@Override
+			public void windowClosed(WindowEvent e) {
+			}
+
+			@Override
+			public void windowClosing(WindowEvent e) {
+			}
+
+			@Override
+			public void windowDeactivated(WindowEvent e) {
+			}
+
+			@Override
+			public void windowDeiconified(WindowEvent e) {
+			}
+
+			@Override
+			public void windowIconified(WindowEvent e) {
+			}
 		});
 	}
-	
+
 	private boolean upToDate() throws IOException {
 		ModPack pack = ModPack.getPack(LaunchFrame.getSelectedModIndex());
 		File version = new File(Settings.getSettings().getInstallPath() + File.separator + pack.getDir() + File.separator + "version");
-		if(!version.exists()){
+		if (!version.exists()) {
 			System.out.println("File not found.");
 			version.getParentFile().mkdirs();
 			version.createNewFile();
@@ -241,19 +259,19 @@ public class ModManager extends JDialog {
 		}
 		BufferedReader in = new BufferedReader(new FileReader(version));
 		String line;
-		if((line = in.readLine()) == null || Integer.parseInt(pack.getVersion()) > Integer.parseInt(line)) {
+		if ((line = in.readLine()) == null || Integer.parseInt(pack.getVersion()) > Integer.parseInt(line)) {
 			System.out.println("File found, out of date.");
 			UpdateDialog p = new UpdateDialog(LaunchFrame.getInstance(), true);
 			p.setVisible(true);
 			in.close();
-			if(!update){
+			if (!update) {
 				return true;
 			}
 			BufferedWriter out = new BufferedWriter(new FileWriter(version));
 			out.write(pack.getVersion());
 			out.flush();
 			out.close();
-			
+
 			return false;
 		} else {
 			System.out.println("File found, up to date.");
@@ -261,14 +279,16 @@ public class ModManager extends JDialog {
 			return true;
 		}
 	}
-	
+
 	public static void cleanUp() {
 		File tempFolder = new File(Settings.getSettings().getInstallPath() + File.separator + "temp" + File.separator + ModPack.getPack(LaunchFrame.getSelectedModIndex()).getDir() + File.separator);
-		for(String file : tempFolder.list()){
-			if(!file.equals("logo_ftb.png") && !file.equals("splash_FTB.png") && !file.equals("version")){
+		for (String file : tempFolder.list()) {
+			if (!file.equals("logo_ftb.png") && !file.equals("splash_FTB.png") && !file.equals("version")) {
 				try {
 					FileUtils.delete(new File(tempFolder, file));
-				} catch (IOException e) { e.printStackTrace(); }
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
 			}
 		}
 	}

--- a/src/net/ftb/gui/dialogs/ProfileAdderDialog.java
+++ b/src/net/ftb/gui/dialogs/ProfileAdderDialog.java
@@ -19,17 +19,17 @@ import net.ftb.gui.LaunchFrame;
 public class ProfileAdderDialog extends JDialog {
 	private static final long serialVersionUID = 1L;
 
-	JPanel panel = new JPanel();
+	final JPanel panel = new JPanel();
 
-	JTextField username = new JTextField(1);
-	JPasswordField password = new JPasswordField(1);
-	JTextField name = new JTextField(1);
+	final JTextField username = new JTextField(1);
+	final JPasswordField password = new JPasswordField(1);
+	final JTextField name = new JTextField(1);
 
-	JLabel userLabel = new JLabel("Username:");
-	JLabel passLabel = new JLabel("Password:");
-	JLabel nameLabel = new JLabel("Profile Name:");
+	final JLabel userLabel = new JLabel("Username:");
+	final JLabel passLabel = new JLabel("Password:");
+	final JLabel nameLabel = new JLabel("Profile Name:");
 
-	JButton addButton = new JButton("Add");
+	final JButton addButton = new JButton("Add");
 
 	public ProfileAdderDialog(LaunchFrame instance, boolean modal) {
 		super(instance, modal);

--- a/src/net/ftb/gui/dialogs/ProfileEditorDialog.java
+++ b/src/net/ftb/gui/dialogs/ProfileEditorDialog.java
@@ -20,18 +20,18 @@ import net.ftb.gui.LaunchFrame;
 public class ProfileEditorDialog extends JDialog {
 	private static final long serialVersionUID = 1L;
 
-	JPanel panel = new JPanel();
+	final JPanel panel = new JPanel();
 
-	JTextField username = new JTextField(1);
-	JPasswordField password = new JPasswordField(1);
-	JTextField name = new JTextField(1);
+	final JTextField username = new JTextField(1);
+	final JPasswordField password = new JPasswordField(1);
+	final JTextField name = new JTextField(1);
 
-	JLabel userLabel = new JLabel("Username:");
-	JLabel passLabel = new JLabel("Password:");
-	JLabel nameLabel = new JLabel("Profile Name:");
+	final JLabel userLabel = new JLabel("Username:");
+	final JLabel passLabel = new JLabel("Password:");
+	final JLabel nameLabel = new JLabel("Profile Name:");
 
-	JButton updateButton = new JButton("Update");
-	JButton removeButton = new JButton("Remove");
+	final JButton updateButton = new JButton("Update");
+	final JButton removeButton = new JButton("Remove");
 
 	public ProfileEditorDialog(LaunchFrame instance, final String editingName, boolean modal) {
 		super(instance, modal);

--- a/src/net/ftb/gui/dialogs/UpdateDialog.java
+++ b/src/net/ftb/gui/dialogs/UpdateDialog.java
@@ -14,11 +14,13 @@ import net.ftb.gui.LaunchFrame;
 import net.ftb.gui.ModManager;
 
 public class UpdateDialog  extends JDialog {
-	private JPanel panel = new JPanel();
-	private JLabel textOne = new JLabel("New mod pack version availible!");
-	private JLabel textTwo = new JLabel("Do you wish to update?");
-	JButton yesButton = new JButton("Yes");
-	JButton noButton = new JButton("No");
+	private static final long serialVersionUID = 1L;
+	
+	private final JPanel panel = new JPanel();
+	private final JLabel textOne = new JLabel("New mod pack version availible!");
+	private final JLabel textTwo = new JLabel("Do you wish to update?");
+	final JButton yesButton = new JButton("Yes");
+	final JButton noButton = new JButton("No");
 
 	public UpdateDialog(LaunchFrame instance, boolean modal) {
 		super(instance, modal);

--- a/src/net/ftb/gui/panes/ModpacksPane.java
+++ b/src/net/ftb/gui/panes/ModpacksPane.java
@@ -28,11 +28,11 @@ import net.ftb.gui.LaunchFrame;
 public class ModpacksPane extends JPanel implements ILauncherPane, ModPackListener {
 	private static final long serialVersionUID = 1L;
 
-	private JPanel packs;
-	private ArrayList<JPanel> packPanels;
-	private JScrollPane packsScroll;
-	private JLabel splash;
-	private JButton serverLink;
+	private final JPanel packs;
+	private final ArrayList<JPanel> packPanels;
+	private final JScrollPane packsScroll;
+	private final JLabel splash;
+	private final JButton serverLink;
 	private static int selectedPack = 0;
 	private boolean modPacksAdded = false;
 
@@ -61,7 +61,7 @@ public class ModpacksPane extends JPanel implements ILauncherPane, ModPackListen
 
 		// stub for a real wait message
 		final JPanel p = new JPanel();
-		p.setBounds(0, 0 * 55, 420, 55);
+		p.setBounds(0, 0, 420, 55);
 		p.setLayout(null);
 
 		JTextArea filler = new JTextArea("please wait while mods are beeing load...");

--- a/src/net/ftb/gui/panes/NewsPane.java
+++ b/src/net/ftb/gui/panes/NewsPane.java
@@ -10,8 +10,8 @@ import javax.swing.border.EmptyBorder;
 public class NewsPane extends JPanel implements ILauncherPane {
 	private static final long serialVersionUID = 1L;
 
-	private JEditorPane news;
-	private JScrollPane newsPanel;
+	private final JEditorPane news;
+	private final JScrollPane newsPanel;
 
 	public NewsPane() {
 		super();

--- a/src/net/ftb/gui/panes/OptionsPane.java
+++ b/src/net/ftb/gui/panes/OptionsPane.java
@@ -22,9 +22,9 @@ public class OptionsPane extends JPanel implements ILauncherPane {
 	private static final long serialVersionUID = 1L;
 	
 	public static JTextField installFolderTextField;
-	private JToggleButton tglbtnForceUpdate;
-	private JTextField ramMinimum;
-	private JTextField ramMaximum;
+	private final JToggleButton tglbtnForceUpdate;
+	private final JTextField ramMinimum;
+	private final JTextField ramMaximum;
 	
 	
 	public OptionsPane () {

--- a/src/net/ftb/tools/MinecraftVersionDetector.java
+++ b/src/net/ftb/tools/MinecraftVersionDetector.java
@@ -12,8 +12,6 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 public class MinecraftVersionDetector {
-	private URLClassLoader cl;
-
 	/**
 	 * Finds out using some clever tricks the current minecraft version version
 	 * @param jarFilePath The .minecraft directory
@@ -33,7 +31,7 @@ public class MinecraftVersionDetector {
 			}
 		}
 
-		cl = new URLClassLoader(urls,this.getClass().getClassLoader());
+		URLClassLoader cl = new URLClassLoader(urls, this.getClass().getClassLoader());
 
 		JarFile file;
 		try {
@@ -45,8 +43,8 @@ public class MinecraftVersionDetector {
 		while (ent.hasMoreElements()) {
 			JarEntry entry = ent.nextElement();
 			if (entry.getName().endsWith(".class")) {
-				if (entry.getName().indexOf("/") == -1) { // it has to be in the root of the jar file
-					Class<?> cls = null;
+				if (!entry.getName().contains("/")) { // it has to be in the root of the jar file
+					Class<?> cls;
 					try {
 						cls = cl.loadClass(entry.getName().split("\\.")[0]);
 					} catch (ClassNotFoundException e1) { continue; } // not a bad error just skip over this entry

--- a/src/net/ftb/util/AppUtils.java
+++ b/src/net/ftb/util/AppUtils.java
@@ -25,9 +25,8 @@ public class AppUtils {
 	 * Reads all of the data from the given stream and returns it as a string.
 	 * @param stream the stream to read from.
 	 * @return the data read from the given stream as a string.
-	 * @throws IOException if an error occurs when reading from the stream.
 	 */
-	public static String readString(InputStream stream) throws IOException {
+	public static String readString(InputStream stream){
 		Scanner scanner = new Scanner(stream).useDelimiter("\\A");
 		return scanner.hasNext() ? scanner.next() : "";
 	}
@@ -36,9 +35,8 @@ public class AppUtils {
 	 * Writes the given string to the given stream.
 	 * @param stream the stream to write to.
 	 * @param str the string to write to the stream.
-	 * @throws IOException if an error occurs when writing to the stream.
 	 */
-	public static void writeString(OutputStream stream, String str) throws IOException {
+	public static void writeString(OutputStream stream, String str){
 		new PrintWriter(stream).write(str);
 	}
 
@@ -46,7 +44,6 @@ public class AppUtils {
 	 * Downloads data from the given URL and returns it as a string.
 	 * @param url the URL to fetch data from.
 	 * @return the data downloaded from the given URL as a string.
-	 * @throws IOException if an error occurs when reading from the stream.
 	 */
 	public static String downloadString(URL url) throws IOException {
 		return readString(url.openStream());

--- a/src/net/ftb/util/FileUtils.java
+++ b/src/net/ftb/util/FileUtils.java
@@ -86,7 +86,7 @@ public class FileUtils {
 	public static void extractZip(String zipLocation) {
 		try {
 			byte[] buf = new byte[1024];
-			ZipInputStream zipinputstream = null;
+			ZipInputStream zipinputstream;
 			ZipEntry zipentry;
 			zipinputstream = new ZipInputStream(new FileInputStream(zipLocation));
 
@@ -125,14 +125,12 @@ public class FileUtils {
 	/**
 	 * Extracts given zip to given location
 	 * @param zipLocation - the location of the zip to be extracted
-	 * @param outputLocation - location to extract to
-	 * @throws IOException
+	 * @param zipPath - location to extract to
 	 */
-	public static void extractZipTo(String zipLocation, String outputLocation) throws IOException {
+	public static void extractZipTo(String zipLocation, String zipPath){
 		try {
 			System.out.println("Entracting");
 			File fSourceZip = new File(zipLocation);
-			String zipPath = outputLocation;
 			File temp = new File(zipPath);
 			temp.mkdir();
 			ZipFile zipFile = new ZipFile(fSourceZip);
@@ -175,7 +173,7 @@ public class FileUtils {
 				}
 				output.putNextEntry(entry);
 				byte buffer[] = new byte[1024];
-				int amo = 0;
+				int amo;
 				while ((amo = input.read(buffer, 0, 1024)) != -1) {
 					output.write(buffer, 0, amo);
 				}

--- a/src/net/ftb/util/OSUtils.java
+++ b/src/net/ftb/util/OSUtils.java
@@ -16,8 +16,7 @@ public class OSUtils {
 			CodeSource codeSource = LaunchFrame.class.getProtectionDomain().getCodeSource();
 			File jarFile;
 			jarFile = new File(codeSource.getLocation().toURI().getPath());
-			String jarDir = jarFile.getParentFile().getPath();
-			return jarDir;
+			return jarFile.getParentFile().getPath();
 		} catch (URISyntaxException e) {
 			e.printStackTrace();
 		}

--- a/src/net/ftb/workers/GameUpdateWorker.java
+++ b/src/net/ftb/workers/GameUpdateWorker.java
@@ -33,10 +33,10 @@ import net.ftb.util.OSUtils.OS;
 public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 	protected String status;
 
-	protected String latestVersion;
-	protected String mainGameURL;
-	protected File binDir;
-	protected boolean forceUpdate;
+	protected final String latestVersion;
+	protected final String mainGameURL;
+	protected final File binDir;
+	protected final boolean forceUpdate;
 
 	protected URL[] jarURLs;
 
@@ -49,7 +49,7 @@ public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 	}
 
 	@Override
-	protected Boolean doInBackground() throws Exception {
+	protected Boolean doInBackground() {
 		setStatus("Determining packages to load...");
 		if (!loadJarURLs()) {
 			return false;
@@ -90,7 +90,7 @@ public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 		// TODO Fix comparison - version format is currently undecided, so this just checks if it has changed.
 		// This could result in a downgrade if the version had gone down - although maybe that's intended?
 		// TODO Ask user if they want to update
-		return !versionFile.exists() || latestVersion == "-1" || latestVersion != readVersionFile();
+		return !versionFile.exists() || latestVersion.equals("-1") || !latestVersion.equals(readVersionFile());
 	}
 
 
@@ -111,7 +111,7 @@ public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 			return false;
 		}
 
-		String nativesFilename = "";
+		String nativesFilename;
 		if (OSUtils.getCurrentOS() == OS.WINDOWS) {
 			nativesFilename = "windows_natives.jar";
 		} else if (OSUtils.getCurrentOS() == OS.MACOSX) {
@@ -140,7 +140,7 @@ public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 			FileInputStream inputStream = new FileInputStream(md5sFile);
 			md5s.load(inputStream);
 			inputStream.close();
-		} catch (FileNotFoundException e) {
+		} catch (FileNotFoundException ignored) {
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
@@ -148,7 +148,7 @@ public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 		int totalDownloadSize = 0;
 		int[] fileSizes = new int[jarURLs.length];
 		boolean[] skip = new boolean[jarURLs.length];
-		URLConnection connection = null;
+		URLConnection connection;
 
 		// Compare MD5s and skip ones that match.
 		for (int i = 0; i < jarURLs.length; i++) {
@@ -188,7 +188,7 @@ public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 		int totalDownloadedSize = 0;
 		for (int i = 0; i < jarURLs.length; i++) {
 			if (skip[i]) {
-				setProgress(initialProgress + fileSizes[i] * 45 / totalDownloadSize);
+				setProgress(initialProgress + ((fileSizes[i] * 45) / totalDownloadSize));
 				continue;
 			}
 
@@ -203,7 +203,7 @@ public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 
 			int triesLeft = 0;
 			boolean downloadSuccess = false;
-			while (!downloadSuccess && triesLeft < 5) {
+			while (!downloadSuccess && (triesLeft < 5)) {
 				try {
 					triesLeft++;
 
@@ -229,7 +229,7 @@ public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 
 					MessageDigest msgDigest = MessageDigest.getInstance("MD5");
 					byte[] buffer = new byte[24000];
-					int readLen = 0;
+					int readLen;
 					int currentDLSize = 0;
 					while ((readLen = dlStream.read(buffer, 0, buffer.length)) != -1) {						
 						outStream.write(buffer, 0, readLen);
@@ -238,7 +238,7 @@ public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 						currentDLSize += readLen;
 						totalDownloadedSize += readLen;
 
-						int prog = i + totalDownloadedSize * 45 / totalDownloadSize;
+						int prog = i + ((totalDownloadedSize * 45) / totalDownloadSize);
 						if (prog > 100) {
 							prog = 100;
 						} else if (prog < 0){
@@ -261,7 +261,7 @@ public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 					}
 
 					if (dlConnection instanceof HttpURLConnection) {
-						if (md5Matches && (currentDLSize == fileSizes[i] || fileSizes[i] <= 0))	{
+						if (md5Matches && ((currentDLSize == fileSizes[i]) || (fileSizes[i] <= 0)))	{
 							downloadSuccess = true;
 							try	{
 								md5s.setProperty(getFilename(jarURLs[i]), etag);
@@ -316,7 +316,7 @@ public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 				setStatus("Extracting " + currentEntry + "...");
 				FileOutputStream outStream = new FileOutputStream(new File(nativesDir, currentEntry.getName()));
 
-				int readLen = 0;
+				int readLen;
 				byte[] buffer = new byte[1024];
 				while ((readLen = zipIn.read(buffer, 0, buffer.length)) > 0) {
 					outStream.write(buffer, 0, readLen);
@@ -352,7 +352,7 @@ public class GameUpdateWorker extends SwingWorker<Boolean, Void> {
 			String retVal = inputStream.readUTF();
 			inputStream.close();
 			return retVal;
-		} catch (FileNotFoundException e) {
+		} catch (FileNotFoundException ignored) {
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/src/net/ftb/workers/LoginWorker.java
+++ b/src/net/ftb/workers/LoginWorker.java
@@ -1,5 +1,6 @@
 package net.ftb.workers;
 
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLEncoder;
 
@@ -12,8 +13,8 @@ import net.ftb.util.AppUtils;
  * response received from the server.
  */
 public class LoginWorker extends SwingWorker<String, Void> {
-	private String username;
-	private String password;
+	private final String username;
+	private final String password;
 
 	public LoginWorker(String username, String password) {
 		super();
@@ -22,7 +23,7 @@ public class LoginWorker extends SwingWorker<String, Void> {
 	}
 
 	@Override
-	protected String doInBackground() throws Exception {
+	protected String doInBackground() throws IOException{
 		StringBuilder requestBuilder = new StringBuilder();
 		requestBuilder.append("https://login.minecraft.net/?user=").append(URLEncoder.encode(username, "UTF-8")).append("&password=")
 		.append(URLEncoder.encode(password, "UTF-8")).append("&version=13");

--- a/src/net/ftb/workers/ModpackLoader.java
+++ b/src/net/ftb/workers/ModpackLoader.java
@@ -26,6 +26,7 @@ public class ModpackLoader extends Thread {
 
 	public ModpackLoader() { }
 
+	@Override
 	public void run() {
 		try {
 			System.out.println("loading modpack information...");
@@ -41,7 +42,7 @@ public class ModpackLoader extends Thread {
 
 			DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
 
-			Document doc = null;
+			Document doc;
 			try {
 				doc = docFactory.newDocumentBuilder().parse(MODPACKSFILE);
 			} catch (SAXException e) {

--- a/src/org/eclipse/wb/swing/FocusTraversalOnArray.java
+++ b/src/org/eclipse/wb/swing/FocusTraversalOnArray.java
@@ -38,8 +38,7 @@ public class FocusTraversalOnArray extends FocusTraversalPolicy {
 	////////////////////////////////////////////////////////////////////////////
 	private int indexCycle(int index, int delta) {
 		int size = m_Components.length;
-		int next = (index + delta + size) % size;
-		return next;
+		return (index + delta + size) % size;
 	}
 	private Component cycle(Component currentComponent, int delta) {
 		int index = -1;
@@ -74,18 +73,23 @@ public class FocusTraversalOnArray extends FocusTraversalPolicy {
 	// FocusTraversalPolicy
 	//
 	////////////////////////////////////////////////////////////////////////////
+	@Override
 	public Component getComponentAfter(Container container, Component component) {
 		return cycle(component, 1);
 	}
+	@Override
 	public Component getComponentBefore(Container container, Component component) {
 		return cycle(component, -1);
 	}
+	@Override
 	public Component getFirstComponent(Container container) {
 		return m_Components[0];
 	}
+	@Override
 	public Component getLastComponent(Container container) {
 		return m_Components[m_Components.length - 1];
 	}
+	@Override
 	public Component getDefaultComponent(Container container) {
 		return getFirstComponent(container);
 	}


### PR DESCRIPTION
- Fixed formatting in `gui.ModManager` - it was very messed up. :(
- Corrected metadata with exe built by maven
- Corrected buildNumber
- Set final any fields which are assigned to only once - if any of these turns out to be in error, please comment here.
- Use new for each syntax for loops
- Add `@Override` where applicable
- Removed `throws Exception` and made more specific
- Removed `throw IOException` in cases where an IOException could never be thrown
- Fixed bug in checking whether to update the modpack. `==` was used instead of `.equals()` when comparing strings, which did not work as intended.
- Fixed bitwise logic when finding the mcDir
- Made some fields which were only being used as local variables into local variables
- Fixed some cases where static methods were being called using an instance
- Fixed some javadoc inconsistencies
- Replaced some uses of `.toArray()` with an empty array as a parameter to using an array of the correct size
- Removed some unnecessary initialisations with `null` or `0`
- Fixed version to be defined as `12`, instead of `012`, which was treated as an octal (resulting in 10, probably not intended.) - maybe a string should be used instead?
- Named Exception `ignored` in cases where nothing was done with it
- Removed redundant local variables

Signed-off-by: Ross Allan rallanpcl@gmail.com
