### PR TITLE
Fix java class path for cross platform support

### DIFF
--- a/src/net/ftb/mclauncher/MinecraftLauncher.java
+++ b/src/net/ftb/mclauncher/MinecraftLauncher.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import net.ftb.log.Logger;
+import net.ftb.util.OSUtils;
 
 
 /**
@@ -32,7 +33,7 @@ public class MinecraftLauncher {
 				for(String name : tempDir.list()) {
 					if(!name.equalsIgnoreCase(forgename)) {
 						if(name.toLowerCase().endsWith(".zip") || name.toLowerCase().endsWith(".jar")) {
-							cpb.append(";");
+							cpb.append(OSUtils.getJavaDelimiter());
 							cpb.append(new File(tempDir, name).getAbsolutePath());
 						}
 					}
@@ -41,11 +42,11 @@ public class MinecraftLauncher {
 				Logger.logInfo("Not a directory.");
 			}
 			// Load forge LAASSSSSST
-			cpb.append(";");
+			cpb.append(OSUtils.getJavaDelimiter());
 			cpb.append(new File(tempDir, forgename).getAbsolutePath());
 			
 			for(int i = 0; i < jarFiles.length; i++) {
-				cpb.append(";");
+				cpb.append(OSUtils.getJavaDelimiter());
 				cpb.append(new File(new File(workingDir, "bin"), jarFiles[i]).getAbsolutePath());
 			}
 

--- a/src/net/ftb/util/OSUtils.java
+++ b/src/net/ftb/util/OSUtils.java
@@ -23,6 +23,21 @@ public class OSUtils {
 		return System.getProperty("user.dir") + "//FTB Pack Install";
 	}
 
+	public static String getJavaDelimiter(){
+		if(getCurrentOS() == OS.WINDOWS){
+			return ";";
+		}
+		else if(getCurrentOS() == OS.UNIX){
+			return ":";
+		}
+		else if(getCurrentOS() == OS.MACOSX){
+			return ":";
+		}
+		else{
+			return ";";
+		}
+	}
+
 	public static OS getCurrentOS() {
 		String osString = System.getProperty("os.name").toLowerCase();
 		if (osString.contains("win")) {


### PR DESCRIPTION
The separator for the class path needs to be different on different operating systems.
Get the right separator for each platform when building the class path.

Signed-off-by: James McKay dcseee-github@yahoo.com.au
