### PR TITLE
SelfUpdate changes - partial revert

### DIFF
--- a/src/net/ftb/gui/LaunchFrame.java
+++ b/src/net/ftb/gui/LaunchFrame.java
@@ -133,13 +133,14 @@ public class LaunchFrame extends JFrame {
 	 */
 	public static void main(String[] args) {
 		// Why would we dynamically check for what version this is? If we've updated the launcher then we should just edit the version on here
-		//		try{
-		//			buildNumber = Integer.parseInt(LaunchFrame.class.getPackage().getImplementationVersion());
-		//			version = LaunchFrame.class.getPackage().getImplementationTitle() + "-b" + buildNumber;
-		//		} catch(Exception e) {
-		//			version = "unknown";
-		//			buildNumber = -1;
-		//		}
+		// Because then you still set it both here and in the pom.
+		try{
+			buildNumber = Integer.parseInt(LaunchFrame.class.getPackage().getImplementationVersion());
+			version = LaunchFrame.class.getPackage().getImplementationTitle() + "-b" + buildNumber;
+		} catch(Exception e) {
+			version = "unknown";
+			buildNumber = -1;
+		}
 		Logger.logInfo("FTBLaunch starting up (version "+ version + ")");
 		{
 			SimpleDateFormat dateFormatGmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
@@ -218,7 +219,7 @@ public class LaunchFrame extends JFrame {
 				ModPack.loadAll();
 
 				if(!version.equalsIgnoreCase("unknown")){
-					UpdateChecker updateChecker = new UpdateChecker(buildNumber);
+					UpdateChecker updateChecker = new UpdateChecker(Settings.getSettings().getChannel(), buildNumber);
 
 					if(updateChecker.shouldUpdate()){
 						LauncherUpdateDialog p = new LauncherUpdateDialog(updateChecker);

--- a/src/net/ftb/updater/Channel.java
+++ b/src/net/ftb/updater/Channel.java
@@ -8,10 +8,10 @@ import net.ftb.gui.LaunchFrame;
 import net.ftb.log.Logger;
 
 public enum Channel {
-	RELEASE("release.xml", "Standard Testing Channel"),
+	RELEASE("http://launcher.feed-the-beast.com/version.xml", "Beta Channel"),// TODO: Maybe swap this over to being hosted on creeper host
 	DEVELOPMENT("http://nallar.me/ftb/b/updateinfo.xml", "Unstable Development Channel"),
 	NONE(null, "Disable automatic updates");
-	private static Channel defaultChannel = NONE;
+	private static Channel defaultChannel = RELEASE;
 	private final String title;
 	public final URL updateURL;
 

--- a/src/net/ftb/updater/UpdateChecker.java
+++ b/src/net/ftb/updater/UpdateChecker.java
@@ -22,14 +22,6 @@ public class UpdateChecker {
 	private int latest;
 	private URL downloadUrl;
 
-	public UpdateChecker(int version) {
-		this.version = version;
-		loadInfo();
-		try {
-			FileUtils.delete(new File(Settings.getSettings().getInstallPath() + File.separator + "updatetemp"));
-		} catch (Exception ignored) { }
-	}
-
 	public UpdateChecker(Channel channel, int version) {
 		this.channel = channel;
 		this.version = version;
@@ -41,15 +33,11 @@ public class UpdateChecker {
 
 	private void loadInfo() {
 		try {
-			Document doc;
-			// TODO: Maybe swap this over to being hosted on creeper host
-			doc = AppUtils.downloadXML(new URL("http://launcher.feed-the-beast.com/version.xml"));
+			Document doc = AppUtils.downloadXML(channel.updateURL);
 			NamedNodeMap updateAttributes = doc.getDocumentElement().getAttributes();
 			latest = Integer.parseInt(updateAttributes.getNamedItem("currentBuild").getTextContent());
 			String downloadAddress = updateAttributes.getNamedItem("downloadURL").getTextContent();
 			if (downloadAddress.indexOf("http") != 0) {
-				// TODO: Make this link work, aka upload the newest launcher onto creeperhost. 
-				// Will be named FTB_Launher.exe or FTB_Launcher.jar
 				downloadAddress = LaunchFrame.getCreeperhostLink(downloadAddress);
 			}
 			downloadUrl = new URL(downloadAddress);


### PR DESCRIPTION
Any commits to the master branch of the repo should be expected to be reasonably stable. Any partial features would be on other branches.

Also, you needn't change the way that gets the URL - just fix the URL in the .xml file, so I removed that todo.

Reason for using version information in the .jar/exe given in comment on https://github.com/Slowpoke101/FTBLaunch/commit/39dece.

Set Release to be the default channel
Now possible to disable automatic updating again.
Selecting dev builds now works again.

Signed-off-by: Ross Allan rallanpcl@gmail.com
