### PR TITLE
Fix launcher console to strip HTML

### DIFF
--- a/src/net/ftb/gui/LauncherConsole.java
+++ b/src/net/ftb/gui/LauncherConsole.java
@@ -215,6 +215,7 @@ public class LauncherConsole extends JDialog implements ILogListener {
 	}
 	
 	private void addText(String text, String color) {
+		text = text.replace("<", "&lt;").replace(">","&gt;");
 		String msg = "<font color=\""+color+"\">"+text+"</font><br/>";
 		try {
 			kit.insertHTML(doc, doc.getLength(), msg, 0, 0, null);


### PR DESCRIPTION
Previously, stack traces containing .`<init>`/etc. would display incorrectly as it was treated as HTML.

Signed-off-by: Ross Allan rallanpcl@gmail.com
