### PR TITLE
Fix issues with OS X App bundles.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,12 +110,13 @@
                 </copy>
                 <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar" tofile="${project.build.directory}/${project.artifactId}.app/Contents/Resources/FTB_Launcher.jar" />
                 <replace file="${project.build.directory}/${project.artifactId}.app/Contents/Info.plist" token="##VERSION##" value="${version}" />
+                <fixcrlf srcdir="${project.build.directory}/${project.artifactId}.app/Contents/MacOS" includes="FTB_Launcher" eol="unix" />
+                <fixcrlf srcdir="${project.build.directory}/${project.artifactId}.app/Contents/" includes="Info.plist" eol="unix" />
                 <chmod file="${project.build.directory}/${project.artifactId}.app/Contents/MacOS/FTB_Launcher" perm="+x" />
                 <zip destfile="${project.build.directory}/${project.artifactId}.app.zip">
 		  <zipfileset dir="${project.build.directory}/${project.artifactId}.app/Contents/MacOS" prefix="${project.artifactId}.app/Contents/MacOS/" filemode="755" />
 		  <zipfileset dir="${project.build.directory}/${project.artifactId}.app/Contents/Resources" prefix="${project.artifactId}.app/Contents/Resources/" />
-		  <zipfileset dir="${project.build.directory}/${project.artifactId}.app/Contents/" prefix="${project.artifactId}.app/Contents/" />
-		  <zipfileset dir="${project.build.directory}/${project.artifactId}.app/" includes="Info.plist" fullpath="${project.artifactId}.app/Contents/Info.plist" />
+		  <zipfileset dir="${project.build.directory}/${project.artifactId}.app/Contents/" includes="Info.plist" fullpath="${project.artifactId}.app/Contents/Info.plist" />
                 </zip>
 		<delete dir="${project.build.directory}/${project.artifactId}.app" />
               </target>


### PR DESCRIPTION
Add code to convert text files (including script files) to unix format
Stop files from being included in the archive twice.

Please note the output file is a text file, so the extension is ".app.zip"
