### PR TITLE
Adding descriptive text to max ram for only 32 bit machines

### DIFF
--- a/res/i18n/daDK
+++ b/res/i18n/daDK
@@ -23,6 +23,8 @@ INSTALL_FOLDER = Installationsmappe...
 FORCE_UPDATE = Gennemtving opdatering?
 RAM_MIN = RAM Minimum (MB)
 RAM_MAX = RAM Maksimum (MB)
+WHY_MAX_RAM = Why is my max 1.5G?
+WHY_MAX_RAM_TOOLTIP = <html>You are running 32 BIT Java,<br /> this limits you to a max of 1.5 gigs,<br /> to be able to use more you need to have a 64 bit OS and 64 bit Java.<html>
 LANGUAGE = Sprog
 
 # Shared strings

--- a/res/i18n/deDE
+++ b/res/i18n/deDE
@@ -23,6 +23,8 @@ INSTALL_FOLDER = Installationsverzeichnis
 FORCE_UPDATE = Update erzwingen?
 RAM_MIN = RAM Minimum (MB)
 RAM_MAX = RAM Maximum (MB)
+WHY_MAX_RAM = Why is my max 1.5G?
+WHY_MAX_RAM_TOOLTIP = <html>You are running 32 BIT Java,<br /> this limits you to a max of 1.5 gigs,<br /> to be able to use more you need to have a 64 bit OS and 64 bit Java.<html>
 LANGUAGE = Sprache
 
 # Shared strings

--- a/res/i18n/enUS
+++ b/res/i18n/enUS
@@ -23,6 +23,8 @@ INSTALL_FOLDER = Install folder...
 FORCE_UPDATE = Force update?
 RAM_MIN = RAM Minimum (MB)
 RAM_MAX = RAM Maximum (MB)
+WHY_MAX_RAM = Why is my max 1.5G?
+WHY_MAX_RAM_TOOLTIP = <html>You are running 32 BIT Java,<br /> this limits you to a max of 1.5 gigs,<br /> to be able to use more you need to have a 64 bit OS and 64 bit Java.<html>
 LANGUAGE = Language
 
 # Shared strings

--- a/res/i18n/nlNL
+++ b/res/i18n/nlNL
@@ -23,6 +23,8 @@ INSTALL_FOLDER = Installatiemap...
 FORCE_UPDATE = Forceer update?
 RAM_MIN = Minimum RAM (MB)
 RAM_MAX = Maximum RAM (MB)
+WHY_MAX_RAM = Why is my max 1.5G?
+WHY_MAX_RAM_TOOLTIP = <html>You are running 32 BIT Java,<br /> this limits you to a max of 1.5 gigs,<br /> to be able to use more you need to have a 64 bit OS and 64 bit Java.<html>
 LANGUAGE = Taal
 
 # Shared strings

--- a/res/i18n/ptBR
+++ b/res/i18n/ptBR
@@ -23,6 +23,8 @@ INSTALL_FOLDER = Pasta de instalação...
 FORCE_UPDATE = Forçar atualização?
 RAM_MIN = RAM Mínima (MB)
 RAM_MAX = RAM Máxima (MB)
+WHY_MAX_RAM = Why is my max 1.5G?
+WHY_MAX_RAM_TOOLTIP = <html>You are running 32 BIT Java,<br /> this limits you to a max of 1.5 gigs,<br /> to be able to use more you need to have a 64 bit OS and 64 bit Java.<html>
 LANGUAGE = Linguagem
 
 # Shared strings

--- a/res/i18n/ptPT
+++ b/res/i18n/ptPT
@@ -23,6 +23,8 @@ INSTALL_FOLDER = Pasta de instalação...
 FORCE_UPDATE = Forçar atualização?
 RAM_MIN = RAM Mínima (MB)
 RAM_MAX = RAM Máxima (MB)
+WHY_MAX_RAM = Why is my max 1.5G?
+WHY_MAX_RAM_TOOLTIP = <html>You are running 32 BIT Java,<br /> this limits you to a max of 1.5 gigs,<br /> to be able to use more you need to have a 64 bit OS and 64 bit Java.<html>
 LANGUAGE = Linguagem
 
 # Shared strings

--- a/res/i18n/ruRU
+++ b/res/i18n/ruRU
@@ -23,6 +23,8 @@ INSTALL_FOLDER = Установочный путь...
 FORCE_UPDATE = Принудительное обновление?
 RAM_MIN = Минимум ОЗУ (Мб)
 RAM_MAX = Максимум ОЗУ (Мб)
+WHY_MAX_RAM = Why is my max 1.5G?
+WHY_MAX_RAM_TOOLTIP = <html>You are running 32 BIT Java,<br /> this limits you to a max of 1.5 gigs,<br /> to be able to use more you need to have a 64 bit OS and 64 bit Java.<html>
 LANGUAGE = Язык
 
 # Shared strings

--- a/res/i18n/svSE
+++ b/res/i18n/svSE
@@ -23,6 +23,8 @@ INSTALL_FOLDER = Installationsmapp:
 FORCE_UPDATE = Tvinga uppdatering?
 RAM_MIN = RAM Minimum (MB)
 RAM_MAX = RAM Maximum (MB)
+WHY_MAX_RAM = Why is my max 1.5G?
+WHY_MAX_RAM_TOOLTIP = <html>You are running 32 BIT Java,<br /> this limits you to a max of 1.5 gigs,<br /> to be able to use more you need to have a 64 bit OS and 64 bit Java.<html>
 LANGUAGE = Språk
 
 # Shared strings

--- a/src/net/ftb/gui/panes/OptionsPane.java
+++ b/src/net/ftb/gui/panes/OptionsPane.java
@@ -39,7 +39,7 @@ public class OptionsPane extends JPanel implements ILauncherPane {
 
 	protected static JTextField installFolderTextField;
 	private JToggleButton tglbtnForceUpdate;
-	private JLabel lblInstallFolder, lblRamMaximum, lblLocale, currentRam;
+	private JLabel lblInstallFolder, lblRamMaximum, lblLocale, currentRam, lblWhyMaxRam;
 	private JSlider ramMaximum;
 	private JComboBox locale;
 
@@ -132,7 +132,7 @@ public class OptionsPane extends JPanel implements ILauncherPane {
 		gbc_lblCurrentRam.insets = new Insets(0, 0, 5, 5);
 		gbc_lblCurrentRam.gridx = 3;
 		gbc_lblCurrentRam.gridy = 6;
-
+                
 		GridBagConstraints gbc_textField_2 = new GridBagConstraints();
 		gbc_textField_2.insets = new Insets(0, 0, 5, 5);
 		gbc_textField_2.fill = GridBagConstraints.HORIZONTAL;
@@ -194,7 +194,18 @@ public class OptionsPane extends JPanel implements ILauncherPane {
 		add(lblRamMaximum, gbc_lblRamMaximum);
 		add(ramMaximum, gbc_textField_2);
 		add(currentRam, gbc_lblCurrentRam);
-
+                
+                if(vmType.equals("32")){
+                    lblWhyMaxRam = new JLabel(I18N.getLocaleString("WHY_MAX_RAM"));
+                    lblWhyMaxRam.setToolTipText(I18N.getLocaleString("WHY_MAX_RAM_TOOLTIP"));
+                    GridBagConstraints gbc_lblWhyMaxRam = new GridBagConstraints();
+                    gbc_lblWhyMaxRam.anchor = GridBagConstraints.WEST;
+                    gbc_lblWhyMaxRam.insets = new Insets(0, 0, 5, 5);
+                    gbc_lblWhyMaxRam.gridx = 4;
+                    gbc_lblWhyMaxRam.gridy = 6;
+                    add(lblWhyMaxRam, gbc_lblWhyMaxRam);
+                }
+                
 		Vector locales = new Vector();
 		for (Map.Entry<Integer, String> entry : I18N.localeIndices.entrySet()) {
 			Logger.logInfo("[i18n] Added " + entry.getKey().toString() + " " + entry.getValue() + " to options pane");


### PR DESCRIPTION
Added descriptive text and tooltip to explain why 32 bit systems have a max of 1.5 gigs.
