### PR TITLE
Logger now partially works in minecraft/update processes.

### DIFF
--- a/src/net/ftb/gui/LauncherConsole.java
+++ b/src/net/ftb/gui/LauncherConsole.java
@@ -8,6 +8,9 @@ import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -26,14 +29,18 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.html.HTMLDocument;
 import javax.swing.text.html.HTMLEditorKit;
 
+import net.ftb.data.Settings;
 import net.ftb.log.ILogListener;
 import net.ftb.log.LogEntry;
 import net.ftb.log.LogLevel;
 import net.ftb.log.LogSource;
 import net.ftb.log.LogType;
+import net.ftb.log.LogWriter;
 import net.ftb.log.Logger;
 
 public class LauncherConsole extends JFrame implements ILogListener {
+	private final static String launcherLogFile = "FTBLauncherLog.txt";
+	private final static String minecraftLogFile = "MinecraftLog.txt";
 	private static final long serialVersionUID = 1L;
 	private final JEditorPane displayArea;
 	private final HTMLEditorKit kit;
@@ -173,6 +180,12 @@ public class LauncherConsole extends JFrame implements ILogListener {
 
 		System.setOut(new OutputOverride(System.out, LogLevel.INFO));
 		System.setErr(new OutputOverride(System.err, LogLevel.ERROR));
+		try {
+			Logger.addListener(new LogWriter(new File(Settings.getSettings().getInstallPath(), launcherLogFile), LogSource.LAUNCHER));
+			Logger.addListener(new LogWriter(new File(Settings.getSettings().getInstallPath(), minecraftLogFile), LogSource.EXTERNAL));
+		} catch (IOException e1) {
+			Logger.logError(e1.getMessage(), e1);
+		}
 	}
 
 	synchronized private void refreshLogs() {

--- a/src/net/ftb/log/LogEntry.java
+++ b/src/net/ftb/log/LogEntry.java
@@ -26,11 +26,11 @@ public class LogEntry {
 		this.message = message;
 		if (level == LogLevel.UNKNOWN) {
 			message = message.toLowerCase();
-			if (message.contains("[severe]") || message.contains("[stderr]")) {
+			if (message.contains("[severe]") || message.contains("[stderr]") || message.contains("[error]")) {
 				level = LogLevel.ERROR;
 			} else if (message.contains("[info]")) {
 				level = LogLevel.INFO;
-			} else if (message.contains("[warning]")) {
+			} else if (message.contains("[warning]") || message.contains("[warn]")) {
 				level = LogLevel.WARN;
 			} else if (message.contains("error") || message.contains("severe")) {
 				level = LogLevel.ERROR;
@@ -80,6 +80,9 @@ public class LogEntry {
 		if (source != LogSource.EXTERNAL) {
 			if (type.includes(LogType.EXTENDED)) {
 				entryMessage.append("[").append(dateString).append("] ");
+			}
+			if (type.includes(LogType.EXTENDED)) {
+				entryMessage.append("[").append(level).append("] ");
 			}
 			if (type.includes(LogType.DEBUG)) {
 				entryMessage.append("in ").append(source).append(" ");

--- a/src/net/ftb/log/LogThread.java
+++ b/src/net/ftb/log/LogThread.java
@@ -1,22 +1,11 @@
 package net.ftb.log;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import net.ftb.data.Settings;
-
 public class LogThread extends Thread {
-	private final static String launcherLogFile = "FTBLauncherLog.txt";
-	private final static String minecraftLogFile = "MinecraftLog.txt";
-
 	private BlockingQueue<LogEntry> logQueue = new LinkedBlockingQueue<LogEntry>();
-	private BufferedWriter launcherLogWriter;
-	private BufferedWriter minecraftLogWriter;
 	private List<ILogListener> listeners;
 
 	public LogThread(List<ILogListener> listeners) {
@@ -25,25 +14,15 @@ public class LogThread extends Thread {
 	}
 
 	public void run() {
-		try {
-			launcherLogWriter = new BufferedWriter(new FileWriter(new File(Settings.getSettings().getInstallPath(), launcherLogFile), true));
-			minecraftLogWriter = new BufferedWriter(new FileWriter(new File(Settings.getSettings().getInstallPath(), minecraftLogFile), true));
-		} catch (IOException e1) {
-			Logger.logError(e1.getMessage(), e1);
-		}
-
 		LogEntry entry;
 		try {
 			while((entry = logQueue.take()) != null) {
-				BufferedWriter logWriter = entry.source == LogSource.EXTERNAL ? minecraftLogWriter : launcherLogWriter;
-				try {
-					logWriter.write(entry.toString(LogType.EXTENDED) + System.getProperty("line.separator"));
-					logWriter.flush();
-				} catch (IOException e) {
-					Logger.logError(e.getMessage(), e);
-				}
-				for (ILogListener listener : listeners) {
-					listener.onLogEvent(entry);
+				if (listeners.size() == 0) {
+					(entry.level == LogLevel.ERROR ? System.err : System.out).println(entry.toString(LogType.EXTENDED));
+				} else {
+					for (ILogListener listener : listeners) {
+						listener.onLogEvent(entry);
+					}
 				}
 			}
 		} catch (InterruptedException ignored) {

--- a/src/net/ftb/log/LogWriter.java
+++ b/src/net/ftb/log/LogWriter.java
@@ -1,0 +1,29 @@
+package net.ftb.log;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+public class LogWriter implements ILogListener {
+	private final BufferedWriter logWriter;
+	private final LogSource source;
+
+	public LogWriter(File logFile, LogSource source) throws IOException {
+		this.source = source;
+		this.logWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(logFile), "UTF-8"));
+	}
+
+	@Override
+	public void onLogEvent(LogEntry entry) {
+		if (entry.source == source) {
+			try {
+				logWriter.write(entry.toString(LogType.EXTENDED) + System.getProperty("line.separator"));
+				logWriter.flush();
+			} catch (IOException e) {
+				Logger.logError(e.getMessage(), e);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Logs are now also saved to disk using a log listener, instead of special-casing it. This was done while refactoring to avoid multiple processes saving to the same logfiles, which doesn't end well.

Signed-off-by: Ross Allan rallanpcl@gmail.com
