### PR TITLE
Allow Users to specify the Java Version Minecraft should use.

### DIFF
--- a/src/net/ftb/data/Settings.java
+++ b/src/net/ftb/data/Settings.java
@@ -85,6 +85,11 @@ public class Settings extends Properties {
 	public String getLocale() {
 		return getProperty("locale", "enUS");
 	}
+	
+	public String getJavaInstall() {
+		String javaHome = System.getProperty("java.home");
+		return getProperty("javaInstall", javaHome);
+	}
 
 	public void setLocale(String locale) {
 		setProperty("locale", locale);
@@ -180,6 +185,10 @@ public class Settings extends Properties {
 	
 	public void setLastAddPath(String string) {
 		setProperty("lastAddPath", string);
+	}
+	
+	public void setJavaInstall(String string) {
+		setProperty("javaInstall", string);
 	}
 	
 //	public void addPrivatePack(String code) {

--- a/src/net/ftb/mclauncher/MinecraftLauncher.java
+++ b/src/net/ftb/mclauncher/MinecraftLauncher.java
@@ -57,7 +57,7 @@ public class MinecraftLauncher {
 		List<String> arguments = new ArrayList<String>();
 
 		String separator = System.getProperty("file.separator");
-		String path = System.getProperty("java.home") + separator + "bin" + separator + "java";
+		String path = Settings.getSettings().getJavaInstall() + separator + "bin" + separator + "java";
 		arguments.add(path);
 
 		setMemory(arguments, rmax);


### PR DESCRIPTION
This is useful for MacOSX users who have Java 6 and 7 installed, since Minecraft won't run with Java 7.

Signed-off-by: fr1zle f@br0tbox.de
