### PR TITLE
Two ModPacks folders are created on Linux and Mac

### DIFF
--- a/src/net/ftb/workers/ModpackLoader.java
+++ b/src/net/ftb/workers/ModpackLoader.java
@@ -36,7 +36,7 @@ public class ModpackLoader extends Thread {
 				privatePack = true;
 			}
 			
-			File modPackFile = new File(OSUtils.getDynamicStorageLocation() + File.separator + "Modpacks" + File.separator + xmlFile[j]);
+			File modPackFile = new File(OSUtils.getDynamicStorageLocation() + File.separator + "ModPacks" + File.separator + xmlFile[j]);
 			try {
 				modPackFile.getParentFile().mkdirs();
 				DownloadUtils.downloadToFile(new URL(DownloadUtils.getStaticCreeperhostLink(xmlFile[j])), modPackFile);


### PR DESCRIPTION
Windows ignores capitalization, Linux and Mac don't.

Result: two folders, named `ModPacks` and `Modpacks`
