### PR TITLE
Fixing private pack settings, completing switch to List<String>; +1 minor change

### DIFF
--- a/src/net/ftb/data/Settings.java
+++ b/src/net/ftb/data/Settings.java
@@ -15,6 +15,7 @@ import java.io.Serializable;
 import java.sql.Date;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.List;
 import java.util.Properties;
 
 import net.ftb.gui.LaunchFrame;
@@ -151,7 +152,7 @@ public class Settings extends Properties {
 			ArrayList<String> packList = getPrivatePacks();
 			if(!packList.contains(code.toLowerCase())) {
 				packList.add(code);
-				setPrivatePacks((String[]) packList.toArray());
+				setPrivatePacks(packList);
 			}
 		} else {
 			setProperty("privatePacks", code);
@@ -163,20 +164,20 @@ public class Settings extends Properties {
 		if(codes.contains(code)) {
 			codes.remove(code);
 		}
-		setPrivatePacks(codes.toArray(new String[]{}));
+		setPrivatePacks(codes);
 	}
 
-	public void setPrivatePacks(String[] codes) {
-		if(codes.length > 0) {
-			String s = codes[0];
-			for(int i = 1; i < codes.length; i++) {
-				s += "," + codes[i];
-			}
-			setProperty("privatePacks", s);
-		} else {
-			setProperty("privatePacks", "");
-		}
-	}
+    public void setPrivatePacks(List<String> codes)
+    {
+        StringBuilder sb = new StringBuilder();
+        String sep = "";
+        for (String s : codes)
+        {
+            sb.append(sep).append(s);
+            sep = ",";
+        }
+        setProperty("privatePacks", sb.toString());
+    }
 
 	public ArrayList<String> getPrivatePacks() {
 		String[] temp = getProperty("privatePacks", "").split(",");

--- a/src/net/ftb/log/LogEntry.java
+++ b/src/net/ftb/log/LogEntry.java
@@ -14,11 +14,11 @@ public class LogEntry {
 	private final String dateString;
 	private final Date date;
 	private final Map<LogType, String> messageCache = new HashMap<LogType, String>();
-	private static final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
+	private static final String dateFormatString = "HH:mm:ss";
 
 	public LogEntry() {
 		this.date = new Date();
-		this.dateString = dateFormat.format(date);
+		this.dateString = new SimpleDateFormat(dateFormatString).format(date);
 		this.location = getLocation(cause);
 	}
 


### PR DESCRIPTION
Made a line-comment in a previous commit about this, but casting the Object[] from List.toArray() to String[] will throw a class cast exception. Either need to use List.toArray(T[] array) version, or change setPrivatePacks to not want a String[] in the first place.

As a minor thing, generally don't want SimpleDateFormat to be static. It's not threadsafe, and it should be cheap enough to just make a formatter when you need it.
