### PR TITLE
Updated launch4j to 1.5.2, fixes #498. Removes unnecessary install goal - included in package.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <url>https://github.com/Slowpoke101/FTBLaunch</url>
 
   <build>
-    <defaultGoal>clean install package</defaultGoal>
+    <defaultGoal>clean package</defaultGoal>
 
     <sourceDirectory>src</sourceDirectory>
     <resources>
@@ -58,9 +58,9 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.bluestemsoftware.open.maven.plugin</groupId>
-        <artifactId>launch4j-plugin</artifactId>
-        <version>1.5.0.0</version>
+				<groupId>com.akathist.maven.plugins.launch4j</groupId>
+				<artifactId>launch4j-maven-plugin</artifactId>
+				<version>1.5.2</version>
         <executions>
           <execution>
             <configuration>


### PR DESCRIPTION
Signed-off-by: Ross Allan rallanpcl@gmail.com
