### PR TITLE
Launching modpack on double-click, fixes #515.

### DIFF
--- a/src/net/ftb/gui/LaunchFrame.java
+++ b/src/net/ftb/gui/LaunchFrame.java
@@ -330,13 +330,7 @@ public class LaunchFrame extends JFrame {
 		launch.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
-				if(users.getSelectedIndex() > 1 && modPacksPane.packPanels.size() > 0) {
-					Settings.getSettings().setLastPack(ModPack.getSelectedPack().getDir());
-					saveSettings();
-					doLogin(UserManager.getUsername(users.getSelectedItem().toString()), UserManager.getPassword(users.getSelectedItem().toString()));
-				} else if(users.getSelectedIndex() <= 1) {
-					ErrorUtils.tossError("Please select a profile!");
-				}
+				doLaunch();
 			}
 		});
 
@@ -980,5 +974,15 @@ public class LaunchFrame extends JFrame {
 		}
 
 		return i;
+	}
+
+	public void doLaunch() {
+		if(users.getSelectedIndex() > 1 && modPacksPane.packPanels.size() > 0) {
+			Settings.getSettings().setLastPack(ModPack.getSelectedPack().getDir());
+			saveSettings();
+			doLogin(UserManager.getUsername(users.getSelectedItem().toString()), UserManager.getPassword(users.getSelectedItem().toString()));
+		} else if(users.getSelectedIndex() <= 1) {
+			ErrorUtils.tossError("Please select a profile!");
+		}
 	}
 }

--- a/src/net/ftb/gui/panes/ModpacksPane.java
+++ b/src/net/ftb/gui/panes/ModpacksPane.java
@@ -199,8 +199,10 @@ public class ModpacksPane extends JPanel implements ILauncherPane, ModPackListen
 		filler.setBackground(new Color(255, 255, 255, 0));
 		MouseListener lin = new MouseListener() {
 			@Override public void mouseClicked(MouseEvent e) {
-				selectedPack = packIndex;
-				updatePacks();
+				if(e.getClickCount() == 2)
+				{
+					LaunchFrame.getInstance().doLaunch();
+				}
 			}
 			@Override public void mouseReleased(MouseEvent e) { }
 			@Override public void mousePressed(MouseEvent e) { 


### PR DESCRIPTION
Does require moving the launch method in LaunchFrame to public scope, so ModpacksPane can call it.

Might want to look into doing something to prevent multiple launches. Basic functionality of double click = launch works though.

Signed-off-by: bolte-17 bolte.17@gmail.com
