### PR TITLE
Change to javaw over standard java

### DIFF
--- a/src/net/ftb/mclauncher/MinecraftLauncher.java
+++ b/src/net/ftb/mclauncher/MinecraftLauncher.java
@@ -58,7 +58,7 @@ public class MinecraftLauncher {
 		List<String> arguments = new ArrayList<String>();
 
 		String separator = System.getProperty("file.separator");
-		String path = System.getProperty("java.home") + separator + "bin" + separator + "java";
+		String path = System.getProperty("java.home") + separator + "bin" + separator + "javaw";
 		arguments.add(path);
 
 		setMemory(arguments, rmax);


### PR DESCRIPTION
Gives some users up to 10 more FPS in some cases and also adds optifine multi-core support to the game, javaw is what is used by standard minecraft so I don't think this will cause any issues I've tested it on a couple of windows machines and it worked fine, not sure about macs/unix but I assume it will be fine and yes I am aware of the fact that this literally changes 1 letter :3
