### PR TITLE
The compatible mod pack checkbox in the texture pack filter is filled with texture resolutions.

### DIFF
--- a/src/net/ftb/gui/dialogs/TexturePackFilterDialog.java
+++ b/src/net/ftb/gui/dialogs/TexturePackFilterDialog.java
@@ -77,7 +77,7 @@ public class TexturePackFilterDialog extends JDialog {
 			}
 		}
 
-		compatiblePack.setModel(new DefaultComboBoxModel(res.toArray(new String[]{})));
+		compatiblePack.setModel(new DefaultComboBoxModel(comp.toArray(new String[]{})));
 		resolution.setModel(new DefaultComboBoxModel(res.toArray(new String[]{})));
 
 		compatiblePack.setSelectedItem(instance.compatible);


### PR DESCRIPTION
This pull request fixes a bug introduced by pull request #536.

The combobox model representing the compatible modpacks in the texture filter dialog is filled with the texture resolutions instead of the compatible mod packs.
