### PR TITLE
Set java options to increase permgen size and enable concurrent mark sweep class unloading. This should resolve crashing issues people are having with mod packs with many mods installed.

### DIFF
--- a/src/net/ftb/mclauncher/MinecraftLauncher.java
+++ b/src/net/ftb/mclauncher/MinecraftLauncher.java
@@ -82,6 +82,8 @@ public class MinecraftLauncher {
 		arguments.add("-XX:+UseConcMarkSweepGC");
 		arguments.add("-XX:+CMSIncrementalMode");
 		arguments.add("-XX:+AggressiveOpts");
+		arguments.add("-XX:+CMSClassUnloadingEnabled");
+		arguments.add("-XX:MaxPermSize=128m");
 
 		arguments.add("-cp");
 		arguments.add(System.getProperty("java.class.path") + cpb.toString());


### PR DESCRIPTION
Signed-off-by: Ross Allan rallanpcl@gmail.com
