### PR TITLE
Allow launcher "Install folder" option to be relative

### DIFF
--- a/src/net/ftb/mclauncher/MinecraftLauncher.java
+++ b/src/net/ftb/mclauncher/MinecraftLauncher.java
@@ -166,7 +166,7 @@ public class MinecraftLauncher {
 			}
 
 			System.out.println("Loading natives...");
-			String nativesDir = new File(new File(basepath, "bin"), "natives").toString();
+			String nativesDir = new File(new File(basepath, "bin"), "natives").getAbsoluteFile().toString();
 			System.out.println("Natives loaded...");
 
 			System.setProperty("org.lwjgl.librarypath", nativesDir);


### PR DESCRIPTION
This fixes a problem encountered on Linux (but may effect other
platforms). Previously, giving a relative path to the "Install folder"
option on the Options tab of the launcher would produce a error in
Minecraft, as it would be passed a non-absolute path for its libraries.

Example:
Install folder...  set to  .feedthebeast
Press Launch

Produced shortly after launch:
    java.lang.UnsatisfiedLinkError: Expecting an absolute path of the library: .feedthebeast/MindCrack/minecraft/bin/natives/liblwjgl.so

Now Produces:
No error, apparently normal operation.
