### PR TITLE
Revert to JPanels

### DIFF
--- a/src/net/ftb/data/Map.java
+++ b/src/net/ftb/data/Map.java
@@ -94,10 +94,6 @@ public class Map {
 		return maps.get(i);
 	}
 
-	public static int size() {
-		return maps.size();
-	}
-
 	/**
 	 * Used to grab the currently selected Map based off the selected index from MapsPane
 	 * @return Map - the currently selected Map

--- a/src/net/ftb/data/ModPack.java
+++ b/src/net/ftb/data/ModPack.java
@@ -114,12 +114,6 @@ public class ModPack {
 		return packs.get(i);
 	}
 
-	/**
-	 * Returns the number of available ModPacks.
-	 */
-	public static int size() {
-		return packs.size();
-	}
 
 	public static ModPack getPack(String dir) {
 		for(ModPack pack : packs) {

--- a/src/net/ftb/data/TexturePack.java
+++ b/src/net/ftb/data/TexturePack.java
@@ -74,10 +74,6 @@ public class TexturePack {
 		return texturePacks.get(i);
 	}
 
-	public static int size() {
-		return texturePacks.size();
-	}
-
 	/**
 	 * Used to grab the currently selected TexturePack based off the selected index from TexturepackPane
 	 * @return TexturePack - the currently selected TexturePack

--- a/src/net/ftb/gui/LaunchFrame.java
+++ b/src/net/ftb/gui/LaunchFrame.java
@@ -115,7 +115,7 @@ public class LaunchFrame extends JFrame {
 	private static String[] dropdown_ = {"Select Profile", "Create Profile"};
 	private static JComboBox users, tpInstallLocation, mapInstallLocation;
 	private static LaunchFrame instance = null;
-	private static String version = "1.2.3";
+	private static String version = "1.2.4";
 
 	public final JTabbedPane tabbedPane = new JTabbedPane(JTabbedPane.TOP);	
 
@@ -391,7 +391,7 @@ public class LaunchFrame extends JFrame {
 			@Override
 			public void actionPerformed(ActionEvent event) {
 				if(!ModPack.getSelectedPack().getServerUrl().isEmpty()) {
-					if(getSelectedModIndex() >= 0) {
+					if(users.getSelectedIndex() > 1 && modPacksPane.packPanels.size() > 0) {
 						try {
 							String version = (Settings.getSettings().getPackVer().equalsIgnoreCase("recommended version") || Settings.getSettings().getPackVer().equalsIgnoreCase("newest version")) ? ModPack.getSelectedPack().getVersion().replace(".", "_") : Settings.getSettings().getPackVer().replace(".", "_");
 							if(ModPack.getSelectedPack().isPrivatePack()) {
@@ -412,7 +412,7 @@ public class LaunchFrame extends JFrame {
 		mapInstall.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
-				if(getSelectedMapIndex() >= 0) {
+				if(mapsPane.mapPanels.size() > 0 && getSelectedMapIndex() >= 0) {
 					MapManager man = new MapManager(new JFrame(), true);
 					man.setVisible(true);
 					MapManager.cleanUp();
@@ -431,7 +431,7 @@ public class LaunchFrame extends JFrame {
 		serverMap.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent event) {
-				if(getSelectedMapIndex() >= 0) {
+				if(mapsPane.mapPanels.size() > 0 && getSelectedMapIndex() >= 0) {
 					try {
 						OSUtils.browse(DownloadUtils.getCreeperhostLink("maps%5E" + Map.getMap(LaunchFrame.getSelectedMapIndex()).getMapName() + "%5E" + Map.getMap(LaunchFrame.getSelectedMapIndex()).getVersion() + "%5E" + Map.getMap(LaunchFrame.getSelectedMapIndex()).getUrl()));
 					} catch (NoSuchAlgorithmException e) { }
@@ -445,7 +445,7 @@ public class LaunchFrame extends JFrame {
 		tpInstall.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
-				if(getSelectedTexturePackIndex() >= 0) {
+				if(tpPane.texturePackPanels.size() > 0 && getSelectedTexturePackIndex() >= 0) {
 					TextureManager man = new TextureManager(new JFrame(), true);
 					man.setVisible(true);
 				}

--- a/src/net/ftb/gui/panes/MapsPane.java
+++ b/src/net/ftb/gui/panes/MapsPane.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of FTB Launcher.
  *
- * Copyright Â© 2012-2013, FTB Launcher Contributors <https://github.com/Slowpoke101/FTBLaunch/>
+ * Copyright © 2012-2013, FTB Launcher Contributors <https://github.com/Slowpoke101/FTBLaunch/>
  * FTB Launcher is licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,7 +17,6 @@
 package net.ftb.gui.panes;
 
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
@@ -30,22 +29,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 
-import javax.swing.AbstractListModel;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JEditorPane;
 import javax.swing.JLabel;
-import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
-import javax.swing.ListCellRenderer;
-import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 
@@ -60,163 +53,40 @@ import net.ftb.locale.I18N;
 import net.ftb.log.Logger;
 import net.ftb.util.OSUtils;
 
-class MapListModelAdapter extends AbstractListModel implements MapListener {
-	private HashMap<Integer, Integer> filteredMaps;
-
-	public MapListModelAdapter() {
-		super();
-		filteredMaps = new HashMap<Integer, Integer>();
-	}
-
-	public void filter(String origin, String compatible, String query) {
-		filteredMaps.clear();
-		int counter = 0;
-		for(int i = 0; i < Map.size(); ++i) {
-			Map map = Map.getMap(i);
-			if(map.isCompatible(ModPack.getSelectedPack().getName()) && originCheck(map, origin) && compatibilityCheck(map, compatible) && textSearch(map, query)) {
-				filteredMaps.put(counter, i);
-				counter++;
-			}
-		}
-		for(int i = 0; i < Map.size(); ++i) {
-			Map map = Map.getMap(i);
-			if((!map.isCompatible(ModPack.getSelectedPack().getName())) && originCheck(map, origin) && compatibilityCheck(map, compatible) && textSearch(map, query)) {
-				filteredMaps.put(counter, i);
-				counter++;
-			}
-		}
-		if(counter + 1 == Map.size()) {
-			filteredMaps.clear();
-			fireIntervalRemoved(this, 0, Map.size());
-			fireIntervalAdded(this, 0, Map.size());
-		}
-		else {
-			fireIntervalRemoved(this, 0, Map.size());
-			fireIntervalAdded(this, 0, filteredMaps.size());
-		}
-	}
-
-	public int getSize() {
-		return (!filteredMaps.isEmpty()) ? filteredMaps.size() : Map.size();
-	}
-
-	public Object getElementAt(int index) {
-		return (!filteredMaps.isEmpty()) ? Map.getMap(filteredMaps.get(index)) : Map.getMap(index);
-	}
-
-	@Override
-	public void onMapAdded(Map map) {
-		Logger.logInfo("Adding map " + Map.size());
-		filteredMaps.clear();
-		fireIntervalAdded(this, Map.size() - 1, Map.size());
-	}
-
-	private static boolean originCheck(Map map, String origin) {
-		return (origin.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL"))) || (origin.equalsIgnoreCase("ftb") && map.getAuthor().equalsIgnoreCase("the ftb team")) || (origin.equalsIgnoreCase(I18N.getLocaleString("FILTER_3THPARTY")) && !map.getAuthor().equalsIgnoreCase("the ftb team"));
-	}
-
-	private static boolean compatibilityCheck(Map map, String compatible) {
-		return (compatible.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || map.isCompatible(compatible));
-	}
-
-	private static boolean textSearch(Map map, String query) {
-		return ((query.isEmpty()) || map.getName().toLowerCase().contains(query) || map.getAuthor().toLowerCase().contains(query));
-	}
-}
-
-class MapCellRenderer extends JPanel implements ListCellRenderer {
-	private JLabel logo;
-	private JTextArea description;
-
-	public MapCellRenderer() {
-		super();
-
-		logo = new JLabel();
-		description = new JTextArea();
-
-		setLayout(null);
-		logo.setBounds(6, 6, 42, 42);
-
-		description.setBorder(null);
-		description.setEditable(false);
-		description.setForeground(Color.white);
-		description.setBounds(58, 6, 378, 42);
-		description.setBackground(new Color(255, 255, 255, 0));
-
-		add(description);
-		add(logo);
-
-		setMinimumSize(new Dimension(420, 55));
-		setPreferredSize(new Dimension(420, 55));
-	}
-
-	public Component getListCellRendererComponent(
-		JList list, Object value, int index, boolean isSelected, boolean cellHasFocus
-	) {
-		Map map = (Map)value;
-
-		if(cellHasFocus || isSelected) {
-			setBackground(UIManager.getColor("control").darker().darker());
-			setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
-		} else {
-			setBackground(UIManager.getColor("control"));
-			setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-		}
-
-		logo.setIcon(new ImageIcon(map.getLogo()));
-		description.setText(map.getName() + " (v." + map.getVersion() + ")\n" + "By " + map.getAuthor());
-
-		return this;
-	}
-}
-
 @SuppressWarnings("serial")
 public class MapsPane extends JPanel implements ILauncherPane, MapListener {
-	private MapListModelAdapter model;
-	private static JList maps;
+	private static JPanel maps;
+	public static ArrayList<JPanel> mapPanels;
 	private static JScrollPane mapsScroll;
 
 	private static JLabel typeLbl;
 	private JButton filter;
-
+	private static int selectedMap = 0;
+	private static boolean mapsAdded = false;
+	public static String type = "Client", origin = "All", compatible = "All";
 	private final MapsPane instance = this;
+
 	private static JEditorPane mapInfo;
 
-	public static String type = "Client", origin = "All", compatible = "All";
 	public static boolean loaded = false;
 
 	private static HashMap<Integer, Map> currentMaps = new HashMap<Integer, Map>();
 
 	public MapsPane() {
 		super();
-		model = new MapListModelAdapter();
+		this.setBorder(new EmptyBorder(5, 5, 5, 5));
+		this.setLayout(null);
 
-		setLayout(null);
+		mapPanels = new ArrayList<JPanel>();
 
-		maps = new JList(model);
-		maps.setCellRenderer(new MapCellRenderer());
+		// TODO: Set loading animation while we wait
+		maps = new JPanel();
+		maps.setLayout(null);
+		maps.setOpaque(false);
 
-		maps.addListSelectionListener(new ListSelectionListener() {
-			public void valueChanged(ListSelectionEvent e) {
-				Map map = (Map)maps.getSelectedValue();
-				if(map != null) {
-					String packs = "";
-					if (map.getCompatible() != null) {
-						packs += "<p>This map works with the following packs:</p><ul>";
-						for (String name : map.getCompatible()) {
-							packs += "<li>" + ModPack.getPack(name).getName() + "</li>";
-						}
-						packs += "</ul>";
-					}
-					LaunchFrame.updateMapInstallLocs(map.getCompatible());
-					File tempDir = new File(OSUtils.getDynamicStorageLocation(), "Maps" + File.separator + map.getMapName());
-					mapInfo.setText("<html><img src='file:///" + tempDir.getPath() + File.separator + map.getImageName() + "' width=400 height=200></img> <br>" + map.getInfo() + packs);
-					mapInfo.setCaretPosition(0);
-				}
-			}
-		});
-		
-		maps.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		final JPanel p = new JPanel();
+		p.setBounds(0, 0, 420, 55);
+		p.setLayout(null);
 
 		filter = new JButton(I18N.getLocaleString("FILTER_SETTINGS"));
 		filter.setBounds(5, 5, 105, 25);
@@ -247,6 +117,15 @@ public class MapsPane extends JPanel implements ILauncherPane, MapListener {
 		typeLbl.setBounds(115, 5, 295, 25);
 		typeLbl.setHorizontalAlignment(SwingConstants.CENTER);
 		add(typeLbl);
+
+		JTextArea filler = new JTextArea(I18N.getLocaleString("MAPS_WAIT_WHILE_LOADING"));
+		filler.setBorder(null);
+		filler.setEditable(false);
+		filler.setForeground(Color.white);
+		filler.setBounds(58, 6, 378, 42);
+		filler.setBackground(new Color(255, 255, 255, 0));
+		p.add(filler);
+		maps.add(p);
 
 		mapsScroll = new JScrollPane();
 		mapsScroll.setBounds(-3, 30, 420, 283);
@@ -288,21 +167,122 @@ public class MapsPane extends JPanel implements ILauncherPane, MapListener {
 		updateFilter();
 	}
 
-	@Override
-	public void onMapAdded(Map map) {
-		model.onMapAdded(map);
+	/*
+	 * GUI Code to add a map to the selection
+	 */
+	public static void addMap(Map map) {
+		if (!mapsAdded) {
+			mapsAdded = true;
+			maps.removeAll();
+		}
+
+		final int mapIndex = mapPanels.size();	
+		final JPanel p = new JPanel();
+		p.setBounds(0, (mapIndex * 55), 420, 55);
+		p.setLayout(null);
+		JLabel logo = new JLabel(new ImageIcon(map.getLogo()));
+		logo.setBounds(6, 6, 42, 42);
+		logo.setVisible(true);
+
+		JTextArea filler = new JTextArea(map.getName() + " (v." + map.getVersion() + ")\n" + "By " + map.getAuthor());
+		filler.setBorder(null);
+		filler.setEditable(false);
+		filler.setForeground(Color.white);
+		filler.setBounds(58, 6, 378, 42);
+		filler.setBackground(new Color(255, 255, 255, 0));
+		MouseAdapter lin = new MouseAdapter() {
+			@Override public void mouseClicked(MouseEvent e) {
+				selectedMap = mapIndex;
+				updateMaps();
+			}
+			@Override public void mousePressed(MouseEvent e) { 
+				selectedMap = mapIndex;
+				updateMaps();
+			}
+		};
+		p.addMouseListener(lin);
+		filler.addMouseListener(lin);
+		logo.addMouseListener(lin);
+		p.add(filler);
+		p.add(logo);
+		mapPanels.add(p);
+		maps.add(p);
+		if(origin.equalsIgnoreCase("all")) {
+			maps.setMinimumSize(new Dimension(420, (Map.getMapArray().size() * 55)));
+			maps.setPreferredSize(new Dimension(420, (Map.getMapArray().size() * 55)));
+		} else {
+			maps.setMinimumSize(new Dimension(420, (currentMaps.size() * 55)));
+			maps.setPreferredSize(new Dimension(420, (currentMaps.size() * 55)));
+		}
+		mapsScroll.revalidate();
 	}
 
-	public void sortMaps() {
-		model.filter(origin, compatible, SearchDialog.lastMapSearch.toLowerCase());
+	@Override
+	public void onMapAdded(Map map) {
+		addMap(map);
+		Logger.logInfo("Adding map " + getMapNum());
+		updateMaps();
+	}
+
+	public static void sortMaps() {
+		mapPanels.clear();
+		maps.removeAll();
+		currentMaps.clear();
+		int counter = 0;
+		selectedMap = 0;
+		maps.repaint();
 		LaunchFrame.updateMapInstallLocs(new String[]{""});
+		mapInfo.setText("");
+		HashMap<Integer, List<Map>> sorted = new HashMap<Integer, List<Map>>();			
+		sorted.put(0, new ArrayList<Map>());
+		sorted.put(1, new ArrayList<Map>());
+		for(Map map : Map.getMapArray()) {
+			if(originCheck(map) && compatibilityCheck(map) && textSearch(map)) {
+				sorted.get((map.isCompatible(ModPack.getSelectedPack().getName())) ? 1 : 0).add(map);
+			}
+		}
+		for(Map map : sorted.get(1)) {
+			addMap(map);
+			currentMaps.put(counter, map);
+			counter++;
+		}
+		for(Map map : sorted.get(0)) {
+			addMap(map);
+			currentMaps.put(counter, map);
+			counter++;
+		}
+		updateMaps();
+	}
+
+	private static void updateMaps() {
+		for (int i = 0; i < mapPanels.size(); i++) {
+			if(selectedMap == i) {
+				String packs = "";
+				if (Map.getMap(getIndex()).getCompatible() != null) {
+					packs += "<p>This map works with the following packs:</p><ul>";
+					for (String name : Map.getMap(getIndex()).getCompatible()) {
+						packs += "<li>" + ModPack.getPack(name).getName() + "</li>";
+					}
+					packs += "</ul>";
+				}
+				mapPanels.get(i).setBackground(UIManager.getColor("control").darker().darker());
+				mapPanels.get(i).setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+				LaunchFrame.updateMapInstallLocs(Map.getMap(getIndex()).getCompatible());
+				File tempDir = new File(OSUtils.getDynamicStorageLocation(), "Maps" + File.separator + Map.getMap(getIndex()).getMapName());
+				mapInfo.setText("<html><img src='file:///" + tempDir.getPath() + File.separator + Map.getMap(getIndex()).getImageName() + "' width=400 height=200></img> <br>" + Map.getMap(getIndex()).getInfo() + packs);
+				mapInfo.setCaretPosition(0);
+			} else {
+				mapPanels.get(i).setBackground(UIManager.getColor("control"));
+				mapPanels.get(i).setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+			}
+		}
 	}
 
 	public static int getSelectedMapIndex() {
-		return maps.getSelectedIndex();
+		return mapsAdded ? getIndex() : -1;
 	}
 
-	public void updateFilter() {
+	public static void updateFilter() {
 		// TODO: Show Modpack specific filtering
 		String filterTextColor = LauncherStyle.getColorAsString(LauncherStyle.getCurrentStyle().filterTextColor);
 		String filterInnerTextColor = LauncherStyle.getColorAsString(LauncherStyle.getCurrentStyle().filterInnerTextColor);
@@ -321,7 +301,33 @@ public class MapsPane extends JPanel implements ILauncherPane, MapListener {
 		LaunchFrame.getInstance().updateFooter();
 	}
 
+	private static int getIndex() {
+		return (currentMaps.size() > 0) ? currentMaps.get(selectedMap).getIndex() : selectedMap;
+	}
+
+	private static int getMapNum() {
+		if(currentMaps.size() > 0) {
+			if(!origin.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL"))) {
+				return currentMaps.get((mapPanels.size() - 1)).getIndex();
+			}
+		}
+		return mapPanels.size();
+	}
+
 	public void updateLocale() {
 		filter.setText(I18N.getLocaleString("FILTER_SETTINGS"));
+	}
+
+	private static boolean originCheck(Map map) {
+		return (origin.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL"))) || (origin.equalsIgnoreCase("ftb") && map.getAuthor().equalsIgnoreCase("the ftb team")) || (origin.equalsIgnoreCase(I18N.getLocaleString("FILTER_3THPARTY")) && !map.getAuthor().equalsIgnoreCase("the ftb team"));
+	}
+
+	private static boolean compatibilityCheck(Map map) {
+		return (compatible.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || map.isCompatible(compatible));
+	}
+
+	private static boolean textSearch(Map map) {
+		String searchString = SearchDialog.lastMapSearch.toLowerCase();
+		return ((searchString.isEmpty()) || map.getName().toLowerCase().contains(searchString) || map.getAuthor().toLowerCase().contains(searchString));
 	}
 }

--- a/src/net/ftb/gui/panes/ModpacksPane.java
+++ b/src/net/ftb/gui/panes/ModpacksPane.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of FTB Launcher.
  *
- * Copyright Â© 2012-2013, FTB Launcher Contributors <https://github.com/Slowpoke101/FTBLaunch/>
+ * Copyright © 2012-2013, FTB Launcher Contributors <https://github.com/Slowpoke101/FTBLaunch/>
  * FTB Launcher is licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,7 +17,6 @@
 package net.ftb.gui.panes;
 
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
@@ -26,27 +25,22 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Map;
 
-import javax.swing.AbstractListModel;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JEditorPane;
 import javax.swing.JLabel;
-import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
-import javax.swing.ListCellRenderer;
-import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.UIManager;
+import javax.swing.border.EmptyBorder;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
 
 import net.ftb.data.LauncherStyle;
 import net.ftb.data.ModPack;
@@ -64,117 +58,10 @@ import net.ftb.util.DownloadUtils;
 import net.ftb.util.OSUtils;
 import net.ftb.util.TrackerUtils;
 
-class ModPackListModelAdapter extends AbstractListModel implements ModPackListener {
-	private Map<Integer, Integer> filteredPacks;
-
-	public ModPackListModelAdapter() {
-		super();
-		filteredPacks = new HashMap<Integer, Integer>();
-	}
-
-	public void filter(String origin, String mcVersion, String availability, String query) {
-		filteredPacks.clear();
-		int counter = 0;
-		for(int i = 0; i < ModPack.size(); ++i) {
-			ModPack pack = ModPack.getPack(i);
-			if(originCheck(pack, origin) && mcVersionCheck(pack, mcVersion) && availabilityCheck(pack, availability) && textSearch(pack, query)) {
-				filteredPacks.put(counter, i);
-				counter++;
-			}
-		}
-		if(counter + 1 == ModPack.size()) {
-			fireIntervalRemoved(this, 0, ModPack.size());
-			fireIntervalAdded(this, 0, ModPack.size());
-			filteredPacks.clear();
-		}
-		else {
-			fireIntervalRemoved(this, 0, ModPack.size());
-			fireIntervalAdded(this, 0, filteredPacks.size());
-		}
-	}
-
-	public int getSize() {
-		return (!filteredPacks.isEmpty()) ? filteredPacks.size() : ModPack.size();
-	}
-
-	public Object getElementAt(int index) {
-		return (!filteredPacks.isEmpty()) ? ModPack.getPack(filteredPacks.get(index)) : ModPack.getPack(index);
-	}
-
-	@Override
-	public void onModPackAdded(ModPack pack) {
-		Logger.logInfo("Adding pack " + ModPack.size());
-		filteredPacks.clear();
-		fireIntervalAdded(this, ModPack.size() - 1, ModPack.size());
-	}
-
-	private static boolean availabilityCheck(ModPack pack, String availability) {
-		return (availability.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL"))) || (availability.equalsIgnoreCase(I18N.getLocaleString("FILTER_PUBLIC")) && !pack.isPrivatePack()) || (availability.equalsIgnoreCase(I18N.getLocaleString("FILTER_PRIVATE")) && pack.isPrivatePack());
-	}
-
-	private static boolean mcVersionCheck(ModPack pack, String mcVersion) {
-		return (mcVersion.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL"))) || (mcVersion.equalsIgnoreCase(pack.getMcVersion()));
-	}
-
-	private static boolean originCheck(ModPack pack, String origin) {
-		return (origin.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL"))) || (origin.equalsIgnoreCase("ftb") && pack.getAuthor().equalsIgnoreCase("the ftb team")) || (origin.equalsIgnoreCase(I18N.getLocaleString("FILTER_3THPARTY")) && !pack.getAuthor().equalsIgnoreCase("the ftb team"));
-	}
-
-	private static boolean textSearch(ModPack pack, String query) {
-		return ((query.isEmpty()) || pack.getName().toLowerCase().contains(query) || pack.getAuthor().toLowerCase().contains(query));
-	}
-}
-
-class ModPackCellRenderer extends JPanel implements ListCellRenderer {
-	private JLabel logo;
-	private JTextArea description;
-
-	public ModPackCellRenderer() {
-		super();
-
-		logo = new JLabel();
-		description = new JTextArea();
-
-		setLayout(null);
-		logo.setBounds(6, 6, 42, 42);
-
-		description.setBorder(null);
-		description.setEditable(false);
-		description.setForeground(Color.white);
-		description.setBounds(58, 6, 378, 42);
-		description.setBackground(new Color(255, 255, 255, 0));
-
-		add(description);
-		add(logo);
-
-		setMinimumSize(new Dimension(420, 55));
-		setPreferredSize(new Dimension(420, 55));
-	}
-
-	public Component getListCellRendererComponent(
-		JList list, Object value, int index, boolean isSelected, boolean cellHasFocus
-	) {
-		ModPack pack = (ModPack)value;
-
-		if(cellHasFocus || isSelected) {
-			setBackground(UIManager.getColor("control").darker().darker());
-			setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
-		} else {
-			setBackground(UIManager.getColor("control"));
-			setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-		}
-
-		logo.setIcon(new ImageIcon(pack.getLogo()));
-		description.setText(pack.getName() + " (v" + pack.getVersion() + ") Minecraft Version " + pack.getMcVersion() + "\n" + "By " + pack.getAuthor());
-
-		return this;
-	}
-}
-
 @SuppressWarnings("serial")
 public class ModpacksPane extends JPanel implements ILauncherPane, ModPackListener {
-	private ModPackListModelAdapter model;
-	private static JList packs;
+	private static JPanel packs;
+	public static ArrayList<JPanel> packPanels;
 	private static JScrollPane packsScroll;
 
 	private static JLabel typeLbl;
@@ -184,8 +71,12 @@ public class ModpacksPane extends JPanel implements ILauncherPane, ModPackListen
 
 	private JButton privatePack;
 	private static JComboBox version;
+	private static int selectedPack = 0;
+	private static boolean modPacksAdded = false;
+	private static HashMap<Integer, ModPack> currentPacks = new HashMap<Integer, ModPack>();
 	private final ModpacksPane instance = this;
 	private static JEditorPane packInfo;
+
 
 	//	private JLabel loadingImage;
 	public static String origin = "All", mcVersion = "All", avaliability = "All";
@@ -193,58 +84,27 @@ public class ModpacksPane extends JPanel implements ILauncherPane, ModPackListen
 
 	private static JScrollPane infoScroll;
 
-	public ModpacksPane() {
+	public ModpacksPane () {
 		super();
-		model = new ModPackListModelAdapter();
-
+		setBorder(new EmptyBorder(5, 5, 5, 5));
 		setLayout(null);
 
-		packs = new JList(model);
-		packs.setCellRenderer(new ModPackCellRenderer());
+		packPanels = new ArrayList<JPanel>();
 
-		packs.addMouseListener(new MouseAdapter() {
-			@Override public void mouseClicked(MouseEvent e) {
-				if(e.getClickCount() == 2) {
-					LaunchFrame.getInstance().doLaunch();
-				}
-			}
-		});
+		// TODO: Set loading animation while we wait
+		//		try {
+		//			loadingImage = new JLabel(new ImageIcon(new URL("http://cdn.nirmaltv.com/images/generatorphp-thumb.gif")));
+		//		} catch (MalformedURLException e1) { e1.printStackTrace(); }
+		//		loadingImage.setLocation(58, 36);
 
-		packs.addListSelectionListener(new ListSelectionListener() {
-			public void valueChanged(ListSelectionEvent e) {
-				ModPack pack = (ModPack)packs.getSelectedValue();
-				if(pack != null) {
-					String mods = "";
-					if(pack.getMods() != null) {
-						mods += "<p>This pack contains the following mods by default:</p><ul>";
-						for (String name : pack.getMods()) {
-							mods += "<li>" + name + "</li>";
-						}
-						mods += "</ul>";
-					}
-					File tempDir = new File(OSUtils.getDynamicStorageLocation(), "ModPacks" + File.separator + pack.getDir());
-					packInfo.setText("<html><img src='file:///" + tempDir.getPath() + File.separator + pack.getImageName() +"' width=400 height=200></img> <br>" + pack.getInfo() + mods);
-					packInfo.setCaretPosition(0);
+		packs = new JPanel();
+		packs.setLayout(null);
+		packs.setOpaque(false);
 
-					if(ModPack.getSelectedPack().getServerUrl().equals("") || ModPack.getSelectedPack().getServerUrl() == null) {
-						server.setEnabled(false);
-					} else {
-						server.setEnabled(true);
-					}
-					String tempVer = Settings.getSettings().getPackVer();
-					version.removeAllItems();
-					version.addItem("Recommended");
-					if(pack.getOldVersions() != null) {
-						for(String s : pack.getOldVersions()) {
-							version.addItem(s);
-						}
-						version.setSelectedItem(tempVer);
-					}
-				}
-			}
-		});
-		
-		packs.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		// stub for a real wait message
+		final JPanel p = new JPanel();
+		p.setBounds(0, 0, 420, 55);
+		p.setLayout(null);
 
 		filter = new JButton(I18N.getLocaleString("FILTER_SETTINGS"));
 		filter.setBounds(5, 5, 105, 25);
@@ -279,13 +139,25 @@ public class ModpacksPane extends JPanel implements ILauncherPane, ModPackListen
 		editModPack.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				if(packs.getSelectedIndex() >= 0) {
-					EditModPackDialog empd = new EditModPackDialog(LaunchFrame.getInstance());
-					empd.setVisible(true);
+				if(packPanels.size() > 0) {
+					if(getSelectedModIndex() >= 0) {
+						EditModPackDialog empd = new EditModPackDialog(LaunchFrame.getInstance());
+						empd.setVisible(true);
+					}
 				}
 			}
 		});
 		add(editModPack);
+
+		JTextArea filler = new JTextArea(I18N.getLocaleString("MODS_WAIT_WHILE_LOADING"));
+		filler.setBorder(null);
+		filler.setEditable(false);
+		filler.setForeground(Color.white);
+		filler.setBounds(58, 6, 378, 42);
+		filler.setBackground(new Color(255, 255, 255, 0));
+		//		p.add(loadingImage);
+		p.add(filler);
+		packs.add(p);
 
 		packsScroll = new JScrollPane();
 		packsScroll.setBounds(-3, 30, 420, 283);
@@ -328,7 +200,7 @@ public class ModpacksPane extends JPanel implements ILauncherPane, ModPackListen
 			@Override
 			public void actionPerformed(ActionEvent event) {
 				if(!ModPack.getSelectedPack().getServerUrl().isEmpty()) {
-					if(packs.getSelectedIndex() >= 0) {
+					if(LaunchFrame.modPacksPane.packPanels.size() > 0 && getSelectedModIndex() >= 0) {
 						try {
 							if(!ModPack.getSelectedPack().getServerUrl().equals("") && ModPack.getSelectedPack().getServerUrl() != null) {
 								String version = (Settings.getSettings().getPackVer().equalsIgnoreCase("recommended version") || Settings.getSettings().getPackVer().equalsIgnoreCase("newest version")) ? ModPack.getSelectedPack().getVersion().replace(".", "_") : Settings.getSettings().getPackVer().replace(".", "_");
@@ -373,27 +245,133 @@ public class ModpacksPane extends JPanel implements ILauncherPane, ModPackListen
 
 	@Override public void onVisible() { }
 
-	@Override
-	public void onModPackAdded(ModPack pack) {
-		model.onModPackAdded(pack);
+	/*
+	 * GUI Code to add a modpack to the selection
+	 */
+	public static void addPack(ModPack pack) {
+		if (!modPacksAdded) {
+			modPacksAdded = true;
+			packs.removeAll();
+		}
+		final int packIndex = packPanels.size();
+		final JPanel p = new JPanel();
+		p.setBounds(0, (packIndex * 55), 420, 55);
+		p.setLayout(null);
+		JLabel logo = new JLabel(new ImageIcon(pack.getLogo()));
+		logo.setBounds(6, 6, 42, 42);
+		logo.setVisible(true);
 
+		JTextArea filler = new JTextArea(pack.getName() + " (v" + pack.getVersion() + ") Minecraft Version " + pack.getMcVersion() + "\n" + "By " + pack.getAuthor());
+		filler.setBorder(null);
+		filler.setEditable(false);
+		filler.setForeground(Color.white);
+		filler.setBounds(58, 6, 378, 42);
+		filler.setBackground(new Color(255, 255, 255, 0));
+		MouseAdapter lin = new MouseAdapter() {
+			@Override public void mouseClicked(MouseEvent e) {
+				if(e.getClickCount() == 2)
+				{
+					LaunchFrame.getInstance().doLaunch();
+				}
+			}
+			@Override public void mousePressed(MouseEvent e) { 
+				selectedPack = packIndex;
+				updatePacks();
+			}
+		};
+		p.addMouseListener(lin);
+		filler.addMouseListener(lin);
+		logo.addMouseListener(lin);
+		p.add(filler);
+		p.add(logo);
+		packPanels.add(p);
+		packs.add(p);
+		if(currentPacks.isEmpty()) {
+			packs.setMinimumSize(new Dimension(420, (ModPack.getPackArray().size() * 55)));
+			packs.setPreferredSize(new Dimension(420, (ModPack.getPackArray().size() * 55)));
+		} else {
+			packs.setMinimumSize(new Dimension(420, (currentPacks.size() * 55)));
+			packs.setPreferredSize(new Dimension(420, (currentPacks.size() * 55)));
+		}
+		packsScroll.revalidate();
 		if(pack.getDir().equalsIgnoreCase(Settings.getSettings().getLastPack())) {
-			packs.setSelectedValue(pack, true);
+			selectedPack = packIndex;
 		}
 	}
 
-	public void sortPacks() {
-		model.filter(origin, mcVersion, avaliability, SearchDialog.lastPackSearch.toLowerCase());
+	@Override
+	public void onModPackAdded(ModPack pack) {
+		addPack(pack);
+		Logger.logInfo("Adding pack " + packPanels.size());
+		updatePacks();
+	}
+
+	public static void sortPacks() {
+		packPanels.clear();
+		packs.removeAll();
+		currentPacks.clear();
+		int counter = 0;
+		selectedPack = 0;
+		packInfo.setText("");
+		packs.repaint();
+		for(ModPack pack : ModPack.getPackArray()) {
+			if(originCheck(pack) && mcVersionCheck(pack) && avaliabilityCheck(pack) && textSearch(pack)) {
+				currentPacks.put(counter, pack);
+				addPack(pack);
+				counter++;
+			}
+		}
+		updatePacks();
+	}
+
+	private static void updatePacks() {
+		for(int i = 0; i < packPanels.size(); i++) {
+			if(selectedPack == i) {
+				ModPack pack = ModPack.getPack(getIndex());
+				if(pack != null) {
+					String mods = "";
+					if(pack.getMods() != null) {
+						mods += "<p>This pack contains the following mods by default:</p><ul>";
+						for (String name : ModPack.getPack(getIndex()).getMods()) {
+							mods += "<li>" + name + "</li>";
+						}
+						mods += "</ul>";
+					}
+					packPanels.get(i).setBackground(UIManager.getColor("control").darker().darker());
+					packPanels.get(i).setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+					File tempDir = new File(OSUtils.getDynamicStorageLocation(), "ModPacks" + File.separator + ModPack.getPack(getIndex()).getDir());
+					packInfo.setText("<html><img src='file:///" + tempDir.getPath() + File.separator + ModPack.getPack(getIndex()).getImageName() +"' width=400 height=200></img> <br>" + ModPack.getPack(getIndex()).getInfo() + mods);
+					packInfo.setCaretPosition(0);
+
+					if(ModPack.getSelectedPack().getServerUrl().equals("") || ModPack.getSelectedPack().getServerUrl() == null) {
+						server.setEnabled(false);
+					} else {
+						server.setEnabled(true);
+					}
+					String tempVer = Settings.getSettings().getPackVer();
+					version.removeAllItems();
+					version.addItem("Recommended");
+					if(pack.getOldVersions() != null) {
+						for(String s : pack.getOldVersions()) {
+							version.addItem(s);
+						}
+						version.setSelectedItem(tempVer);
+					}
+				}
+			} else {
+				packPanels.get(i).setBackground(UIManager.getColor("control"));
+				packPanels.get(i).setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+			}
+		}
 	}
 
 	public static int getSelectedModIndex() {
-		return packs.getSelectedIndex();
+		return modPacksAdded ? getIndex() : -1;
 	}
 
-	public void updateFilter() {
+	public static void updateFilter() {
 		String filterTextColor = LauncherStyle.getColorAsString(LauncherStyle.getCurrentStyle().filterTextColor);
 		String filterInnerTextColor = LauncherStyle.getColorAsString(LauncherStyle.getCurrentStyle().filterInnerTextColor);
-
 		String typeLblText = "<html><body>";
 		typeLblText += "<strong><font color=rgb\"(" + filterTextColor + ")\">Filter: </strong></font>";
 		typeLblText += "<font color=rgb\"(" + filterInnerTextColor + ")\">" + origin + "</font>";
@@ -406,6 +384,10 @@ public class ModpacksPane extends JPanel implements ILauncherPane, ModPackListen
 		LaunchFrame.getInstance().updateFooter();
 	}
 
+	private static int getIndex() {
+		return (!currentPacks.isEmpty()) ? currentPacks.get(selectedPack).getIndex() : selectedPack;
+	}
+
 	public void updateLocale() {
 		filter.setText(I18N.getLocaleString("FILTER_SETTINGS"));
 		editModPack.setText(I18N.getLocaleString("MODS_EDIT_PACK"));
@@ -416,5 +398,22 @@ public class ModpacksPane extends JPanel implements ILauncherPane, ModPackListen
 			editModPack.setBounds(300, 5, 110, 25);
 			typeLbl.setBounds(115, 5, 175, 25);
 		}
+	}
+
+	private static boolean avaliabilityCheck(ModPack pack) {
+		return (avaliability.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL"))) || (avaliability.equalsIgnoreCase(I18N.getLocaleString("FILTER_PUBLIC")) && !pack.isPrivatePack()) || (avaliability.equalsIgnoreCase(I18N.getLocaleString("FILTER_PRIVATE")) && pack.isPrivatePack());
+	}
+
+	private static boolean mcVersionCheck(ModPack pack) {
+		return (mcVersion.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL"))) || (mcVersion.equalsIgnoreCase(pack.getMcVersion()));
+	}
+
+	private static boolean originCheck(ModPack pack) {
+		return (origin.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL"))) || (origin.equalsIgnoreCase("ftb") && pack.getAuthor().equalsIgnoreCase("the ftb team")) || (origin.equalsIgnoreCase(I18N.getLocaleString("FILTER_3THPARTY")) && !pack.getAuthor().equalsIgnoreCase("the ftb team"));
+	}
+
+	private static boolean textSearch(ModPack pack) {
+		String searchString = SearchDialog.lastPackSearch.toLowerCase();
+		return ((searchString.isEmpty()) || pack.getName().toLowerCase().contains(searchString) || pack.getAuthor().toLowerCase().contains(searchString));
 	}
 }

--- a/src/net/ftb/gui/panes/TexturepackPane.java
+++ b/src/net/ftb/gui/panes/TexturepackPane.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of FTB Launcher.
  *
- * Copyright Â© 2012-2013, FTB Launcher Contributors <https://github.com/Slowpoke101/FTBLaunch/>
+ * Copyright © 2012-2013, FTB Launcher Contributors <https://github.com/Slowpoke101/FTBLaunch/>
  * FTB Launcher is licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,7 +17,6 @@
 package net.ftb.gui.panes;
 
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
@@ -29,22 +28,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.swing.AbstractListModel;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JEditorPane;
 import javax.swing.JLabel;
-import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
-import javax.swing.ListCellRenderer;
-import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 
@@ -60,169 +53,41 @@ import net.ftb.locale.I18N;
 import net.ftb.log.Logger;
 import net.ftb.util.OSUtils;
 
-class TexturePackListModelAdapter extends AbstractListModel implements TexturePackListener {
-	private HashMap<Integer, Integer> filteredPacks;
-
-	public TexturePackListModelAdapter() {
-		super();
-		filteredPacks = new HashMap<Integer, Integer>();
-	}
-
-	public void filter(String compatible, String resolution, String query) {
-		filteredPacks.clear();
-		int counter = 0;
-		for(int i = 0; i < TexturePack.size(); ++i) {
-			TexturePack texturePack = TexturePack.getTexturePack(i);
-			if(texturePack.isCompatible(ModPack.getSelectedPack().getDir()) && compatibilityCheck(texturePack, compatible) && resolutionCheck(texturePack, resolution) && textSearch(texturePack, query)) {
-				filteredPacks.put(counter, i);
-				counter++;
-			}
-		}
-		for(int i = 0; i < TexturePack.size(); ++i) {
-			TexturePack texturePack = TexturePack.getTexturePack(i);
-			if(!texturePack.isCompatible(ModPack.getSelectedPack().getDir()) && compatibilityCheck(texturePack, compatible) && resolutionCheck(texturePack, resolution) && textSearch(texturePack, query)) {
-				filteredPacks.put(counter, i);
-				counter++;
-			}
-		}
-		if(counter + 1 == TexturePack.size()) {
-			filteredPacks.clear();
-			fireIntervalRemoved(this, 0, TexturePack.size());
-			fireIntervalAdded(this, 0, TexturePack.size());
-		}
-		else {
-			fireIntervalRemoved(this, 0, TexturePack.size());
-			fireIntervalAdded(this, 0, filteredPacks.size());
-		}
-	}
-
-	public int getSize() {
-		return (!filteredPacks.isEmpty()) ? filteredPacks.size() : TexturePack.size();
-	}
-
-	public Object getElementAt(int index) {
-		return (!filteredPacks.isEmpty()) ? TexturePack.getTexturePack(filteredPacks.get(index)) : TexturePack.getTexturePack(index);
-	}
-
-	@Override
-	public void onTexturePackAdded(TexturePack texturePack) {
-		Logger.logInfo("Adding texture pack " + TexturePack.size());
-		filteredPacks.clear();
-		fireIntervalAdded(this, TexturePack.size() - 1, TexturePack.size());
-	}
-
-	private static boolean compatibilityCheck(TexturePack tp, String compatible) {
-		return (compatible.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || tp.isCompatible(compatible));
-	}
-
-	private static boolean resolutionCheck(TexturePack tp, String resolution) {
-		return (resolution.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || tp.getResolution().equalsIgnoreCase(resolution));
-	}
-
-	private static boolean textSearch(TexturePack tp, String query) {
-		return ((query.isEmpty()) || tp.getName().toLowerCase().contains(query) || tp.getAuthor().toLowerCase().contains(query));
-	}
-}
-
-class TexturePackCellRenderer extends JPanel implements ListCellRenderer {
-	private JLabel logo;
-	private JTextArea description;
-
-	public TexturePackCellRenderer() {
-		super();
-
-		logo = new JLabel();
-		description = new JTextArea();
-
-		setLayout(null);
-		logo.setBounds(6, 6, 42, 42);
-
-		description.setBorder(null);
-		description.setEditable(false);
-		description.setForeground(Color.white);
-		description.setBounds(58, 6, 378, 42);
-		description.setBackground(new Color(255, 255, 255, 0));
-
-		add(description);
-		add(logo);
-
-		setMinimumSize(new Dimension(420, 55));
-		setPreferredSize(new Dimension(420, 55));
-	}
-
-	public Component getListCellRendererComponent(
-		JList list, Object value, int index, boolean isSelected, boolean cellHasFocus
-	) {
-		TexturePack pack = (TexturePack)value;
-
-		if(cellHasFocus || isSelected) {
-			setBackground(UIManager.getColor("control").darker().darker());
-			setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
-		} else {
-			setBackground(UIManager.getColor("control"));
-			setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-		}
-
-		String info = "";
-		if(pack.getInfo().length() > 60) {
-			info = pack.getInfo().substring(0, 59) + "...";
-		} else {
-			info = pack.getInfo();
-		}
-
-		logo.setIcon(new ImageIcon(pack.getLogo()));
-		description.setText(pack.getName() + " : " + pack.getAuthor() + "\n" + info);
-
-		return this;
-	}
-}
-
 @SuppressWarnings("serial")
 public class TexturepackPane extends JPanel implements ILauncherPane, TexturePackListener {
-	private TexturePackListModelAdapter model;
-	private static JList texturePacks;
+	private static JPanel texturePacks;
+	public static ArrayList<JPanel> texturePackPanels;
 	private static JScrollPane texturePacksScroll;
 
 	private static JLabel typeLbl;
+	public static String compatible = "All", resolution = "All";
 	private JButton filter;
-
-	private TexturepackPane instance = this;
+	private static boolean texturePacksAdded = false;
+	private static int selectedTexturePack = 0;
 	private static JEditorPane textureInfo;
 
-	public static String compatible = "All", resolution = "All";
+	private TexturepackPane instance = this;
+
+	private static HashMap<Integer, TexturePack> currentTexturePacks = new HashMap<Integer, TexturePack>();
+
 	public static boolean loaded = false;
 
 	public TexturepackPane() {
 		super();
-		model = new TexturePackListModelAdapter();
+		this.setBorder(new EmptyBorder(5, 5, 5, 5));
+		this.setLayout(null);
 
-		setLayout(null);
+		texturePackPanels = new ArrayList<JPanel>();
 
-		texturePacks = new JList(model);
-		texturePacks.setCellRenderer(new TexturePackCellRenderer());
+		// TODO: Set loading animation while we wait
+		texturePacks = new JPanel();
+		texturePacks.setLayout(null);
+		texturePacks.setOpaque(false);
 
-		texturePacks.addListSelectionListener(new ListSelectionListener() {
-			public void valueChanged(ListSelectionEvent e) {
-				TexturePack pack = (TexturePack)texturePacks.getSelectedValue();
-				if(pack != null) {
-					String packs = "";
-					if (pack.getCompatible() != null) {
-						packs += "<p>This texture pack works with the following packs:</p><ul>";
-						for (String name : pack.getCompatible()) {
-							packs += "<li>" + ModPack.getPack(name).getName() + "</li>";
-						}
-						packs += "</ul>";
-					}
-					LaunchFrame.updateTpInstallLocs(pack.getCompatible());
-					File tempDir = new File(OSUtils.getDynamicStorageLocation(), "TexturePacks" + File.separator + pack.getName());
-					textureInfo.setText("<html><img src='file:///" + tempDir.getPath() + File.separator + pack.getImageName() +"' width=400 height=200></img> <br>" + pack.getInfo() + packs);
-					textureInfo.setCaretPosition(0);
-				}
-			}
-		});
+		final JPanel p = new JPanel();
+		p.setBounds(0, 0, 420, 55);
+		p.setLayout(null);
 
-		texturePacks.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-		
 		filter = new JButton(I18N.getLocaleString("FILTER_SETTINGS"));
 		filter.setBounds(5, 5, 105, 25);
 		filter.addActionListener(new ActionListener() {
@@ -248,6 +113,15 @@ public class TexturepackPane extends JPanel implements ILauncherPane, TexturePac
 		typeLbl.setBounds(115, 5, 295, 25);
 		typeLbl.setHorizontalAlignment(SwingConstants.CENTER);
 		add(typeLbl);
+
+		JTextArea filler = new JTextArea(I18N.getLocaleString("TEXTURE_WAIT_WHILE_LOADING"));
+		filler.setBorder(null);
+		filler.setEditable(false);
+		filler.setForeground(Color.white);
+		filler.setBounds(58, 6, 378, 42);
+		filler.setBackground(new Color(255, 255, 255, 0));
+		p.add(filler);
+		texturePacks.add(p);
 
 		texturePacksScroll = new JScrollPane();
 		texturePacksScroll.setBounds(-3, 30, 420, 283);
@@ -288,27 +162,129 @@ public class TexturepackPane extends JPanel implements ILauncherPane, TexturePac
 		updateFilter();
 	}
 
-	@Override
-	public void onTexturePackAdded(TexturePack texturePack) {
-		model.onTexturePackAdded(texturePack);
+	/*
+	 * GUI Code to add a texture pack to the selection
+	 */
+	public static void addTexturePack(TexturePack texturePack) {
+		if (!texturePacksAdded) {
+			texturePacksAdded = true;
+			texturePacks.removeAll();
+		}
+
+		final int texturePackIndex = texturePackPanels.size();
+
+		final JPanel p = new JPanel();
+		p.setBounds(0, (texturePackIndex * 55), 420, 55);
+		p.setLayout(null);
+		JLabel logo = new JLabel(new ImageIcon(texturePack.getLogo()));
+		logo.setBounds(6, 6, 42, 42);
+		logo.setVisible(true);
+		String info = "";
+		if(texturePack.getInfo().length() > 60) {
+			info = texturePack.getInfo().substring(0, 59) + "...";
+		} else {
+			info = texturePack.getInfo();
+		}
+		JTextArea filler = new JTextArea(texturePack.getName() + " : " + texturePack.getAuthor() + "\n" + info);
+		filler.setBorder(null);
+		filler.setEditable(false);
+		filler.setForeground(Color.white);
+		filler.setBounds(58, 6, 378, 42);
+		filler.setBackground(new Color(255, 255, 255, 0));
+		MouseAdapter lin = new MouseAdapter() {
+			@Override public void mouseClicked(MouseEvent e) {
+				selectedTexturePack = texturePackIndex;
+				updateTexturePacks();
+			}
+		};
+		p.addMouseListener(lin);
+		filler.addMouseListener(lin);
+		logo.addMouseListener(lin);
+		p.add(filler);
+		p.add(logo);
+		texturePackPanels.add(p);
+		texturePacks.add(p);
+		if(compatible.equalsIgnoreCase("all") && resolution.equalsIgnoreCase("all")) {
+			texturePacks.setMinimumSize(new Dimension(420, (TexturePack.getTexturePackArray().size()) * 55));
+			texturePacks.setPreferredSize(new Dimension(420, (TexturePack.getTexturePackArray().size()) * 55));
+		} else {
+			texturePacks.setMinimumSize(new Dimension(420, (currentTexturePacks.size()) * 55));
+			texturePacks.setPreferredSize(new Dimension(420, (currentTexturePacks.size()) * 55));
+		}
+		texturePacksScroll.revalidate();
 	}
 
-	public void sortTexturePacks() {
-		model.filter(compatible, resolution, SearchDialog.lastTextureSearch.toLowerCase());
+	@Override
+	public void onTexturePackAdded(TexturePack texturePack) {
+		addTexturePack(texturePack);
+		Logger.logInfo("Adding texture pack " + getTexturePackNum());
+		updateTexturePacks();
+	}
+
+	public static void sortTexturePacks() {
+		texturePackPanels.clear();
+		texturePacks.removeAll();
+		currentTexturePacks.clear();
+		int counter = 0;
+		selectedTexturePack = 0;
+		texturePacks.repaint();
+		HashMap<Integer, List<TexturePack>> sorted = new HashMap<Integer, List<TexturePack>>();			
+		sorted.put(0, new ArrayList<TexturePack>());
+		sorted.put(1, new ArrayList<TexturePack>());
+		for(TexturePack texturePack : TexturePack.getTexturePackArray()) {
+			if(compatibilityCheck(texturePack) && resolutionCheck(texturePack) && textSearch(texturePack)) {
+				sorted.get((texturePack.isCompatible(ModPack.getSelectedPack().getDir())) ? 1 : 0).add(texturePack);
+			}
+		}
+		for(TexturePack tp : sorted.get(1)) {
+			addTexturePack(tp);
+			currentTexturePacks.put(counter, tp);
+			counter++;
+		}
+		for(TexturePack tp : sorted.get(0)) {
+			addTexturePack(tp);
+			currentTexturePacks.put(counter, tp);
+			counter++;
+		}
+		updateTexturePacks();
+	}
+
+	private static void updateTexturePacks() {
+		for(int i = 0; i < texturePackPanels.size(); i++) {
+			if(selectedTexturePack == i) {
+				String packs = "";
+				if (TexturePack.getTexturePack(getIndex()).getCompatible() != null) {
+					packs += "<p>This texture pack works with the following packs:</p><ul>";
+					for (String name : TexturePack.getTexturePack(getIndex()).getCompatible()) {
+						packs += "<li>" + ModPack.getPack(name).getName() + "</li>";
+					}
+					packs += "</ul>";
+				}
+				texturePackPanels.get(i).setBackground(UIManager.getColor("control").darker().darker());
+				texturePackPanels.get(i).setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+				LaunchFrame.updateTpInstallLocs(TexturePack.getTexturePack(getIndex()).getCompatible());
+				File tempDir = new File(OSUtils.getDynamicStorageLocation(), "TexturePacks" + File.separator + TexturePack.getTexturePack(getIndex()).getName());
+				textureInfo.setText("<html><img src='file:///" + tempDir.getPath() + File.separator + TexturePack.getTexturePack(getIndex()).getImageName() +"' width=400 height=200></img> <br>" + TexturePack.getTexturePack(getIndex()).getInfo() + packs);
+				textureInfo.setCaretPosition(0);
+			} else {
+				texturePackPanels.get(i).setBackground(UIManager.getColor("control"));
+				texturePackPanels.get(i).setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+			}
+		}
 	}
 
 	public static int getSelectedTexturePackIndex() {
-		return texturePacks.getSelectedIndex();
+		return texturePacksAdded ? getIndex() : -1;
 	}
 
-	public void updateFilter() {
+	public static void updateFilter() {
 		String filterTextColor = LauncherStyle.getColorAsString(LauncherStyle.getCurrentStyle().filterTextColor);
 		String filterInnerTextColor = LauncherStyle.getColorAsString(LauncherStyle.getCurrentStyle().filterInnerTextColor);
 
 		String typeLblText = "<html><body>";
 		typeLblText += "<strong><font color=rgb\"(" + filterTextColor + ")\">Filter: </strong></font>";
 		typeLblText += "<font color=rgb\"(" + filterInnerTextColor + ")\">" + compatible + "</font>";
-		typeLblText += "<font color=rgb\"(" + filterTextColor + ")\"> / </font>";
+		typeLblText += "<strong><font color=rgb\"(" + filterTextColor + ")\"> / </strong></font>";
 		typeLblText += "<font color=rgb\"(" + filterInnerTextColor + ")\">" + resolution + "</font>";
 		typeLblText += "</body></html>";
 
@@ -317,7 +293,33 @@ public class TexturepackPane extends JPanel implements ILauncherPane, TexturePac
 		LaunchFrame.getInstance().updateFooter();
 	}
 
+	private static int getIndex() {
+		return (currentTexturePacks.size() > 0) ? currentTexturePacks.get(selectedTexturePack).getIndex() : selectedTexturePack;
+	}
+
+	private static int getTexturePackNum() {
+		if(currentTexturePacks.size() > 0) {
+			if(!compatible.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || !resolution.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL"))) {
+				return currentTexturePacks.get((texturePackPanels.size() - 1)).getIndex();
+			}
+		}
+		return texturePackPanels.size();
+	}
+
 	public void updateLocale() {
 		filter.setText(I18N.getLocaleString("FILTER_SETTINGS"));
+	}
+
+	private static boolean compatibilityCheck(TexturePack tp) {
+		return (compatible.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || tp.isCompatible(compatible));
+	}
+
+	private static boolean resolutionCheck(TexturePack tp) {
+		return (resolution.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || tp.getResolution().equalsIgnoreCase(resolution));
+	}
+
+	private static boolean textSearch(TexturePack tp) {
+		String searchString = SearchDialog.lastTextureSearch.toLowerCase();
+		return ((searchString.isEmpty()) || tp.getName().toLowerCase().contains(searchString) || tp.getAuthor().toLowerCase().contains(searchString));
 	}
 }


### PR DESCRIPTION
I reverted the listing of modpacks, maps and texture packs to use JPanels rather than JList as the JList solution was causing the launcher to hang on startup if there was any user input and there were also many filter issues. I had to manually revert to avoid breaking other things
