### PR TITLE
Corrects a crash on Windows when JDK 1.7.0 is installed

### DIFF
--- a/src/net/ftb/util/winreg/JavaInfo.java
+++ b/src/net/ftb/util/winreg/JavaInfo.java
@@ -40,9 +40,9 @@ public class JavaInfo implements Comparable<JavaInfo> {
         
         String[] s = this.version.split("[._-]");
         this.major = Integer.parseInt(s[0]);
-        this.minor = Integer.parseInt(s[1]);
-        this.revision = Integer.parseInt(s[2]);
-        this.build = Integer.parseInt(s[3]); 
+        this.minor = s.length > 1 ? Integer.parseInt(s[1]) : 0;
+        this.revision = s.length > 2 ? Integer.parseInt(s[2]) : 0;
+        this.build = s.length > 3 ? Integer.parseInt(s[3]) : 0; 
 
     }
 


### PR DESCRIPTION
As per the feed-the-beast [forum thread](http://forum.feed-the-beast.com/threads/ftb-launcher-crash.35990/), this crash is due to incorrect handling of Java versions with a nonexistent build number.  In this case, the build number is omitted, and an out-of-bounds exception occurs.  This fixes that problem, and also hardens nearby codepaths in the event that they are subject to the same vulnerability.
