### PR TITLE
Improved support for users with 32-bit Java on Windows

### DIFF
--- a/res/i18n/enUS
+++ b/res/i18n/enUS
@@ -27,6 +27,8 @@ SHOW_CONSOLE = Show Console?
 REOPEN_LAUNCHER = Reopen launcher after exiting minecraft?
 ADVANCED_OPTIONS = Advanced Options
 INSTALL_FIRSTUSE = Since this is your first time using the launcher, we suggest setting the install directory.
+DOWNLOAD_JAVA64 = Download Java 64-bit
+JAVA_32BIT_WARNING = Your system is using a 32-bit version of Java. This will limit Minecraft to 1.5gb of RAM.
 
 # Shared strings
 FILTER_SETTINGS = Filter Settings


### PR DESCRIPTION
ADDED: 32 Bit Java warning message in Options tab
ADDED: 64 Bit Java install button in Options tab for users with 64 bit OS but 32 Bit JVM
CHANGED: Increased maximum RAM for 32 Bit users from 1024mb to 1536mb (up to 1792mb is safe)
