### PR TITLE
Launcher memory usage changes

### DIFF
--- a/src/net/ftb/gui/panes/OptionsPane.java
+++ b/src/net/ftb/gui/panes/OptionsPane.java
@@ -22,9 +22,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
-import java.lang.management.ManagementFactory;
-import java.lang.management.OperatingSystemMXBean;
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Map;
 
@@ -55,7 +52,7 @@ import net.ftb.util.winreg.JavaFinder;
 public class OptionsPane extends JPanel implements ILauncherPane {
 	private JToggleButton tglbtnForceUpdate;
 	private JButton installBrowseBtn, advancedOptionsBtn, btnInstallJava;
-	private JLabel lblInstallFolder, lblRamMaximum, lblLocale, currentRam, minecraftSize, lblX, lbl32BitWarning;
+	private JLabel lblJavaVersion, lblInstallFolder, lblRamMaximum, lblLocale, currentRam, minecraftSize, lblX, lbl32BitWarning;
 	private JSlider ramMaximum;
 	private JComboBox locale;
 	private JTextField installFolderTextField;
@@ -104,22 +101,7 @@ public class OptionsPane extends JPanel implements ILauncherPane {
 
 		currentRam = new JLabel();
 		currentRam.setBounds(427, 95, 85, 25);
-		long ram = 0;
-		OperatingSystemMXBean operatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean();
-		Method m;
-		try {
-			m = operatingSystemMXBean.getClass().getDeclaredMethod("getTotalPhysicalMemorySize");
-			m.setAccessible(true);
-			Object value = m.invoke(operatingSystemMXBean);
-			if(value != null) {
-				ram = Long.valueOf(value.toString()) / 1024 / 1024;
-			} else {
-				Logger.logWarn("Could not get RAM Value");
-				ram = 8192;
-			}
-		} catch (Exception e) {
-			Logger.logError(e.getMessage(), e);
-		}
+		long ram = OSUtils.getOSTotalMemory();
 
 		ramMaximum = new JSlider();
 		ramMaximum.setBounds(190, 95, 222, 25);
@@ -140,7 +122,11 @@ public class OptionsPane extends JPanel implements ILauncherPane {
 				if(ram < 1024) {
 					ramMaximum.setMaximum((int)ram);
 				} else {
-					ramMaximum.setMaximum(1024);
+				    if(ram > 2536) {
+                        ramMaximum.setMaximum(1536);
+                    } else {
+                        ramMaximum.setMaximum(1024);
+                    }
 				}
 			}
 		}
@@ -246,6 +232,12 @@ public class OptionsPane extends JPanel implements ILauncherPane {
 		});
 		advancedOptionsBtn.getModel().setPressed(settings.getForceUpdate());
 		add(advancedOptionsBtn);
+		
+		if (OSUtils.getCurrentOS().equals(OS.WINDOWS) && JavaFinder.parseWinJavaVersion().path != null) {
+		    lblJavaVersion = new JLabel("Java version: " + JavaFinder.parseWinJavaVersion().origVersion);
+    		lblJavaVersion.setBounds(15,276,250,25);
+    		add(lblJavaVersion);
+		}
 	}
 
 	public void setInstallFolderText(String text) {

--- a/src/net/ftb/mclauncher/MinecraftLauncherNew.java
+++ b/src/net/ftb/mclauncher/MinecraftLauncherNew.java
@@ -77,13 +77,26 @@ public class MinecraftLauncherNew
 		arguments.add(path);
 
 		setMemory(arguments, rmax);
-		if(OSUtils.getCurrentOS().equals(OS.WINDOWS)) {
-            // Detect if OS is 64 or 32 bit
+		
+	    if(OSUtils.getCurrentOS().equals(OS.WINDOWS)) {
             String arch = System.getenv("PROCESSOR_ARCHITECTURE");
             String wow64Arch = System.getenv("PROCESSOR_ARCHITEW6432");
-            if(!(arch.endsWith("64") || (wow64Arch != null && wow64Arch.endsWith("64"))))
-                 if(maxPermSize == null || maxPermSize.isEmpty()) maxPermSize = "128m";}
-		    if(maxPermSize == null || maxPermSize.isEmpty()) maxPermSize = "256m";
+	        if(!(arch.endsWith("64") || (wow64Arch != null && wow64Arch.endsWith("64")))) {
+	            if(maxPermSize == null || maxPermSize.isEmpty()) {
+	                if(OSUtils.getOSTotalMemory() > 2048) {
+	                    maxPermSize = "192m";
+	                } else {
+	                    maxPermSize = "128m";
+	                }
+	            }
+	        }
+	    }
+	    
+        if(maxPermSize == null || maxPermSize.isEmpty()) {
+        	// 64-bit or Non-Windows
+        	maxPermSize = "256m";
+        }
+		
 		//arguments.add("-XX:+UseConcMarkSweepGC");
 		//arguments.add("-XX:+CMSIncrementalMode");
 		//arguments.add("-XX:+AggressiveOpts");

--- a/src/net/ftb/util/OSUtils.java
+++ b/src/net/ftb/util/OSUtils.java
@@ -18,6 +18,9 @@ package net.ftb.util;
 
 import java.awt.Desktop;
 import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.Method;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.URI;
@@ -78,6 +81,28 @@ public class OSUtils {
 		}
 	}
 
+    public static long getOSTotalMemory() {
+        long ram = 0;
+        
+        OperatingSystemMXBean operatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean();
+		Method m;
+		try {
+			m = operatingSystemMXBean.getClass().getDeclaredMethod("getTotalPhysicalMemorySize");
+			m.setAccessible(true);
+			Object value = m.invoke(operatingSystemMXBean);
+			if(value != null) {
+				ram = Long.valueOf(value.toString()) / 1024 / 1024;
+			} else {
+				Logger.logWarn("Could not get RAM Value");
+				ram = 1024;
+			}
+		} catch (Exception e) {
+			Logger.logError(e.getMessage(), e);
+		}
+		
+		return ram;
+    }
+    
 	/**
 	 * Used to get the java delimiter for current OS
 	 * @return string containing java delimiter for current OS

--- a/src/net/ftb/util/winreg/JavaFinder.java
+++ b/src/net/ftb/util/winreg/JavaFinder.java
@@ -140,8 +140,14 @@ public class JavaFinder
                         prefered = java32.get(i);
                 }
             }
-            Logger.logInfo("FTB Launcher Prefers: " + prefered.toString());
-            return prefered;
+            
+            if(prefered == null) {
+            	Logger.logError("No Java versions found!");
+            	return null;
+            } else {
+	            Logger.logInfo("FTB Launcher Prefers: " + prefered.toString());
+	            return prefered;
+            }
         }
     }
 }


### PR DESCRIPTION
ADDED: Java version display to options tab
ADDED: Console error message if Java registry entries are not found at all
CHANGED: Allow launcher to allocate up to 1.5gb of ram on 32-bit systems with > 2.5gb ram
CHANGED: Use 192mb PermSize for MC 1.6 and up on 32-bit systems with > 2gb ram (64-bit systems already use 256mb here)
CHANGED: Use 192mb PermSize for MC 1.5 or lower on all systems with > 2gb ram
CHANGED: Moved shared code to check total OS memory from OptionsPane to OSUtils
