### PR TITLE
RFC: Simple resume support for pack downloads

### DIFF
--- a/src/net/ftb/tools/ModManager.java
+++ b/src/net/ftb/tools/ModManager.java
@@ -96,59 +96,99 @@ public class ModManager extends JDialog {
 			FileOutputStream fout = null;
 			HttpURLConnection connection = null;
 			String md5 = "";
+			int amount = 0, startAmount = -1, modPackSize = 0, count = 0, steps = 0;
+			int retryCount = 5;
+			
 			try {
-				URL url_ = new URL(urlString);
-				byte data[] = new byte[1024];
-				connection = (HttpURLConnection) url_.openConnection();
-				connection.setAllowUserInteraction(true);
-				connection.setConnectTimeout(14000);
-				connection.setReadTimeout(20000);
-				connection.connect();
-				md5 = connection.getHeaderField("Content-MD5");
-				in = new BufferedInputStream(connection.getInputStream());
 				fout = new FileOutputStream(filename);
-				int count, amount = 0, modPackSize = connection.getContentLength(), steps = 0;
-				SwingUtilities.invokeLater(new Runnable() {
-					public void run() {
-						progressBar.setMaximum(10000);
-					}
-				});
-				while((count = in.read(data, 0, 1024)) != -1) {
-					fout.write(data, 0, count);
-					downloadedPerc += (count * 1.0 / modPackSize) * 100;
-					amount += count;
-					steps++;
-					if(steps > 100) {
-						steps = 0;
-						final String txt = (amount / 1024) + "Kb / " + (modPackSize / 1024) + "Kb";
-						final int perc =  (int)downloadedPerc * 100;
-						SwingUtilities.invokeLater(new Runnable() {
-							public void run() {
-								progressBar.setValue(perc);
-								label.setText(txt);
-							}
-						});
-					}
-				}
-			} catch (MalformedURLException e) {
-				e.printStackTrace();
 			} catch (IOException e) {
 				e.printStackTrace();
-			} finally {
+				Logger.logError("Failed opening output file: " + filename);
+				return null;
+			}
+
+			do {
+				try {
+					startAmount = amount;
+					
+					if(amount > 0) {
+						Logger.logInfo("Resuming download from offset " + Integer.toString(amount));
+					}
+					
+					URL url_ = new URL(urlString);
+					byte data[] = new byte[1024];
+					SwingUtilities.invokeLater(new Runnable() {
+						public void run() {
+							progressBar.setMaximum(10000);
+						}
+					});
+					
+					connection = (HttpURLConnection) url_.openConnection();
+					connection.setAllowUserInteraction(true);
+					connection.setConnectTimeout(14000);
+					connection.setReadTimeout(20000);
+					if(amount > 0) {
+						connection.setRequestProperty("Range", "bytes=" + amount + "-");
+					}
+					connection.connect();
+					md5 = connection.getHeaderField("Content-MD5");
+					in = new BufferedInputStream(connection.getInputStream());
+					if(modPackSize == 0) {
+						modPackSize = connection.getContentLength();
+					} else {
+						if(amount + connection.getContentLength() != modPackSize) {
+							throw new IOException("Resume failed");
+						} else {
+							Logger.logInfo("Resume started sucessfully");
+						}
+					}
+					
+					while((count = in.read(data, 0, 1024)) != -1) {
+						fout.write(data, 0, count);
+						
+						if(count > 0)
+							retryCount = 5;
+
+						downloadedPerc += (count * 1.0 / modPackSize) * 100;
+						amount += count;
+						steps++;
+						if(steps > 100) {
+							steps = 0;
+							final String txt = (amount / 1024) + "Kb / " + (modPackSize / 1024) + "Kb";
+							final int perc =  (int)downloadedPerc * 100;
+							SwingUtilities.invokeLater(new Runnable() {
+								public void run() {
+									progressBar.setValue(perc);
+									label.setText(txt);
+								}
+							});
+						}
+					}
+				} catch (MalformedURLException e) {
+					e.printStackTrace();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+				
 				try {
 					if(in != null) {
 						in.close();
-					}
-					if(fout != null) {
-						fout.flush();
-						fout.close();
 					}
 					if(connection != null) {
 						connection.disconnect();
 					}
 				} catch (IOException e) {
 					e.printStackTrace();
+				}				
+			} while(amount < modPackSize && (amount > startAmount || retryCount-- > 0));
+			
+			try {
+				if(fout != null) {
+					fout.flush();
+					fout.close();
 				}
+			} catch (IOException e) {
+				e.printStackTrace();
 			}
 			return md5;
 		}


### PR DESCRIPTION
Instead of simply throwing an error message and aborting the entire 100+mb pack download when a user's internet drops out for a moment, I propose to let the launcher try to open a new connection, which will resume the download from the point it dropped out. 

This will not allow users to cancel a pack download and resume it later, but it will hopefully completely resolve download issues for those with unreliable internet connections.

This is easily implemented using the Range header built into HTTP 1.1, and is fully supported by the CreeperHost/CreeperRepo servers.

My attached implementation will constantly retry the download as long as more data has been received since the last attempt, so for intermittent connections that may drop hundreds of times through the process, we won't give up as long as we're making headway.

It has a hard limit of 5 retries if no data has been received since the last attempt. This is to stop the downloader getting stuck in an infinite loop and users needing to end process it to cancel the download.

It will also check on each retry that the amount of data being sent (which should be the remainder of the pack archive), when added to the amount of data already stored, is equal to the expected total size of the pack archive. This means that if corruption does happen to occur during the resume process, it will likely be caught before any further data is downloaded, which will avoid wasting any more of the user's time.

The timeouts already in use by the launcher are 14 seconds for a connection, and 20 seconds for reading data. I haven't changed these. This means that if a user's connection drops mid-download, the progress bar will stall for a maximum of 90 seconds before aborting (20 seconds for a read timeout, then 14 seconds per connection attempt for 5 retries). If the user tries to launch again, the download will not be resumed, and they will re-download the entire archive.
