### PR TITLE
Ignore local/virtual/p2p interfaces when searching for MAC address

### DIFF
--- a/src/net/ftb/util/OSUtils.java
+++ b/src/net/ftb/util/OSUtils.java
@@ -179,7 +179,7 @@ public class OSUtils {
 			while(networkInterfaces.hasMoreElements()) {
 				NetworkInterface network = networkInterfaces.nextElement();
 				byte[] mac = network.getHardwareAddress();
-				if(mac != null && mac.length > 0) {
+				if(mac != null && mac.length > 0 && !network.isLoopback() && !network.isVirtual() && !network.isPointToPoint()) {
 					cachedMacAddress = new byte[mac.length * 10];
 					for(int i = 0; i < cachedMacAddress.length; i++) {
 						cachedMacAddress[i] = mac[i - (Math.round(i / mac.length) * mac.length)];


### PR DESCRIPTION
This will resolve issues experienced by users who have a high priority point-to-point (VPN), or virtual (virtual machine, ip6to4 tunnel, etc) adapter, who currently have their login credentials tied to a MAC address which can change at any time.

The launcher already includes a check to make sure the MAC address is not blank, which seems meant to ignore nonsense adapters, but it does not cover all cases. By adding the checks in this commit, the system will more reliably choose a _real_ network adapter to use as a login key.
