### PR TITLE
Fix memory detection issues when running the launcher on a 32-bit JVM

### DIFF
--- a/src/net/ftb/gui/panes/OptionsPane.java
+++ b/src/net/ftb/gui/panes/OptionsPane.java
@@ -102,6 +102,7 @@ public class OptionsPane extends JPanel implements ILauncherPane {
 		currentRam = new JLabel();
 		currentRam.setBounds(427, 95, 85, 25);
 		long ram = OSUtils.getOSTotalMemory();
+		long freeram = OSUtils.getOSFreeMemory();
 
 		ramMaximum = new JSlider();
 		ramMaximum.setBounds(190, 95, 222, 25);
@@ -122,7 +123,7 @@ public class OptionsPane extends JPanel implements ILauncherPane {
 				if(ram < 1024) {
 					ramMaximum.setMaximum((int)ram);
 				} else {
-				    if(ram > 2536) {
+				    if(freeram > 2046) {
                         ramMaximum.setMaximum(1536);
                     } else {
                         ramMaximum.setMaximum(1024);

--- a/src/net/ftb/mclauncher/MinecraftLauncherNew.java
+++ b/src/net/ftb/mclauncher/MinecraftLauncherNew.java
@@ -83,7 +83,7 @@ public class MinecraftLauncherNew
             String wow64Arch = System.getenv("PROCESSOR_ARCHITEW6432");
             if(!(arch.endsWith("64") || (wow64Arch != null && wow64Arch.endsWith("64")))) {
 	            if(maxPermSize == null || maxPermSize.isEmpty()) {
-	                if(OSUtils.getOSTotalMemory() > 2048) {
+	                if(OSUtils.getOSTotalMemory() > 2046) {
 	                    maxPermSize = "192m";
 	                    Logger.logInfo("Defaulting PermSize to 192m");
 	                } else {


### PR DESCRIPTION
CHANGED: Require 2gb of free memory instead of 2.5gb of total memory for the 1.5gb memory limit on 32-bit systems
FIXED: Use 192mb permgen when a user has 2gb of memory on a 32-bit system (was only using 192mb when _above_ 2gb)
