### PR TITLE
Fixes 1.7 assets downloading

### DIFF
--- a/src/net/ftb/gui/LaunchFrame.java
+++ b/src/net/ftb/gui/LaunchFrame.java
@@ -688,7 +688,7 @@ public class LaunchFrame extends JFrame {
 			TextureManager.updateTextures();
 		} catch (Exception e1) { }
 		
-		if (pack.getMcVersion().startsWith("1.6") || pack.getVersion().startsWith("1.7"))
+		if (pack.getMcVersion().startsWith("1.6") || pack.getMcVersion().startsWith("1.7"))
 		{
 		    setupNewStyle(installPath, pack);
 		    return;


### PR DESCRIPTION
When downloading the minecraft assets, the minecraft version check is incorrect for 1.7 packs. The pack version is checked instead. This causes 1.7 packs to attempt the old download method, which obviously fails.
