### PR TITLE
Allow launcher "Install folder" option to be relative

### DIFF
--- a/src/net/ftb/mclauncher/MinecraftLauncher.java
+++ b/src/net/ftb/mclauncher/MinecraftLauncher.java
@@ -145,6 +145,8 @@ public class MinecraftLauncher {
 		String basepath = args[0], animationname = args[1], forgename = args[2], username = args[3], password = args[4], modPackName = args[5], modPackImageName = args[6];
 		Settings.getSettings().save();  //Call so that the settings file is loaded from the correct location.  Would be wrong on OS X and *nix if called after user.home is reset
 
+		basepath = new File(basepath).getAbsoluteFile().toString();
+
 		try {
 			System.out.println("Loading jars...");
 			String[] jarFiles = new String[] {"minecraft.jar", "lwjgl.jar", "lwjgl_util.jar", "jinput.jar" };

--- a/src/net/ftb/mclauncher/MinecraftLauncherNew.java
+++ b/src/net/ftb/mclauncher/MinecraftLauncherNew.java
@@ -163,6 +163,8 @@ public class MinecraftLauncherNew
 		String basepath = args[0], animationname = args[1], forgename = args[2], username = args[3], password = args[4], modPackName = args[5], modPackImageName = args[6];
 		Settings.getSettings().save();  //Call so that the settings file is loaded from the correct location.  Would be wrong on OS X and *nix if called after user.home is reset
 
+		basepath = new File(basepath).getAbsoluteFile().toString();
+		
 		try {
 			System.out.println("Loading jars...");
 			String[] jarFiles = new String[] {"minecraft.jar", "lwjgl.jar", "lwjgl_util.jar", "jinput.jar" };


### PR DESCRIPTION
Variant of https://github.com/Slowpoke101/FTBLaunch/pull/567

Provides support for both old and new MC versions, and correctly implements the change for the classpath, etc too.

This change only impacts non-Windows systems, and should be quite safe for all users.
