### PR TITLE
Fix getUsernames to return usernames instead of profile names

### DIFF
--- a/src/net/ftb/data/UserManager.java
+++ b/src/net/ftb/data/UserManager.java
@@ -113,7 +113,7 @@ public class UserManager {
     public static ArrayList<String> getUsernames () {
         ArrayList<String> ret = new ArrayList<String>();
         for (User user : _users) {
-            ret.add(user.getName());
+            ret.add(user.getUsername());
         }
         return ret;
     }


### PR DESCRIPTION
In `UserManager` class the methods `getUsernames()` and `getNames()` both call `user.getName()` although `getUsernames()` most likely was intenteded to use the `user.getUsername()` method.
