### PR TITLE
Log OS and JVM bitness

### DIFF
--- a/src/net/ftb/gui/LaunchFrame.java
+++ b/src/net/ftb/gui/LaunchFrame.java
@@ -192,15 +192,24 @@ public class LaunchFrame extends JFrame {
         thread.start();
 
         Logger.logInfo("FTBLaunch starting up (version " + version + ")");
-        Logger.logInfo("Java version: " + System.getProperty("java.version"));
+        Logger.logInfo("Java version: " + System.getProperty("java.version") + " (" + (OSUtils.is64BitOS()?"64-bit":"32-bit") +")");
         Logger.logInfo("Java vendor: " + System.getProperty("java.vendor"));
         Logger.logInfo("Java home: " + System.getProperty("java.home"));
         Logger.logInfo("Java specification: " + System.getProperty("java.vm.specification.name") + " version: " + System.getProperty("java.vm.specification.version") + " by "
                 + System.getProperty("java.vm.specification.vendor"));
         Logger.logInfo("Java vm: " + System.getProperty("java.vm.name") + " version: " + System.getProperty("java.vm.version") + " by " + System.getProperty("java.vm.vendor"));
-        Logger.logInfo("OS: " + System.getProperty("os.arch") + " " + System.getProperty("os.name") + " " + System.getProperty("os.version"));
+        Logger.logInfo("OS: " + (OSUtils.is64BitOS()?"64-bit":"32-bit") + " " + System.getProperty("os.name") + " " + System.getProperty("os.version"));
         Logger.logInfo("Launcher Install Dir: " + Settings.getSettings().getInstallPath());
         Logger.logInfo("System memory: " + OSUtils.getOSFreeMemory() + "M free, " + OSUtils.getOSTotalMemory() + "M total");
+
+        if (!OSUtils.is64BitOS()) {
+            Logger.logInfo("Warning: 32 Bit operating system. 64 Bit is encouraged for most mod packs. If you have issues, please try the FTB Lite 2 pack.");
+        }
+
+        if (OSUtils.is64BitOS() && !OSUtils.is64BitVM()) {
+            Logger.logInfo("Warning: 32 Bit Java in 64 Bit operating system. 64 Bit Java is encouraged for most mod packs. If you have issues, please try the FTB Lite 2 pack.");
+        }
+
 
         // Use IPv4 when possible, only use IPv6 when connecting to IPv6 only addresses
         System.setProperty("java.net.preferIPv4Stack", "true");

--- a/src/net/ftb/gui/panes/OptionsPane.java
+++ b/src/net/ftb/gui/panes/OptionsPane.java
@@ -112,16 +112,12 @@ public class OptionsPane extends JPanel implements ILauncherPane {
         ramMaximum.setMajorTickSpacing(256);
         ramMaximum.setMinorTickSpacing(256);
         ramMaximum.setMinimum(256);
-        String vmType = new String();
-        if (OSUtils.getCurrentOS().equals(OS.WINDOWS) && JavaFinder.parseWinJavaVersion() != null) {
-            vmType = JavaFinder.parseWinJavaVersion().is64bits ? "64" : "32";
-        } else {
-            vmType = System.getProperty("sun.arch.data.model");
-        }
-        if (vmType != null) {
-            if (vmType.equals("64")) {
+
+        Boolean vm64Bits = OSUtils.is64BitVM();
+        if (vm64Bits != null) {
+            if (vm64Bits) {
                 ramMaximum.setMaximum((int) ram);
-            } else if (vmType.equals("32")) {
+            } else {
                 if (ram < 1024) {
                     ramMaximum.setMaximum((int) ram);
                 } else {
@@ -178,18 +174,14 @@ public class OptionsPane extends JPanel implements ILauncherPane {
         add(locale);
 
         // Dependant on vmType from earlier RAM calculations to detect 64 bit JVM 
-        if (vmType.equals("32")) {
+        if (!OSUtils.is64BitVM()) {
             lbl32BitWarning = new JLabel(I18N.getLocaleString("JAVA_32BIT_WARNING"));
             lbl32BitWarning.setBounds(190, 170, 500, 25);
             lbl32BitWarning.setForeground(Color.red);
             add(lbl32BitWarning);
 
             if (OSUtils.getCurrentOS().equals(OS.WINDOWS)) {
-                // Detect if OS is 64 or 32 bit
-                String arch = System.getenv("PROCESSOR_ARCHITECTURE");
-                String wow64Arch = System.getenv("PROCESSOR_ARCHITEW6432");
-
-                if (arch.endsWith("64") || (wow64Arch != null && wow64Arch.endsWith("64"))) {
+                if (OSUtils.is64BitWindows()) {
                     btnInstallJava = new JButton(I18N.getLocaleString("DOWNLOAD_JAVA64"));
                     btnInstallJava.addActionListener(new ActionListener() {
                         @Override

--- a/src/net/ftb/mclauncher/MinecraftLauncherNew.java
+++ b/src/net/ftb/mclauncher/MinecraftLauncherNew.java
@@ -66,9 +66,7 @@ public class MinecraftLauncherNew {
         setMemory(arguments, rmax);
 
         if (OSUtils.getCurrentOS().equals(OSUtils.OS.WINDOWS)) {
-            String arch = System.getenv("PROCESSOR_ARCHITECTURE");
-            String wow64Arch = System.getenv("PROCESSOR_ARCHITEW6432");
-            if (!(arch.endsWith("64") || (wow64Arch != null && wow64Arch.endsWith("64")))) {
+            if (!OSUtils.is64BitWindows()) {
                 if (maxPermSize == null || maxPermSize.isEmpty()) {
                     if (OSUtils.getOSTotalMemory() > 2046) {
                         maxPermSize = "192m";

--- a/src/net/ftb/util/OSUtils.java
+++ b/src/net/ftb/util/OSUtils.java
@@ -17,10 +17,13 @@
 package net.ftb.util;
 
 import java.awt.Desktop;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
+import java.lang.Runtime;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.URI;
@@ -31,6 +34,8 @@ import java.util.Enumeration;
 import lombok.Getter;
 import net.ftb.gui.LaunchFrame;
 import net.ftb.log.Logger;
+import net.ftb.util.winreg.JavaFinder;
+
 
 public class OSUtils {
     private static byte[] cachedMacAddress;
@@ -164,6 +169,69 @@ public class OSUtils {
             return OS.OTHER;
         }
     }
+
+    /**
+     * Used to check if Windows is 64-bit
+     * @return true if 64-bit Windows
+     */
+    public static boolean is64BitWindows() {
+        String arch = System.getenv("PROCESSOR_ARCHITECTURE");
+        String wow64Arch = System.getenv("PROCESSOR_ARCHITEW6432");
+        return (arch.endsWith("64") || (wow64Arch != null && wow64Arch.endsWith("64")));
+    }
+
+    /**
+     * Used to check if Linux is 64-bit
+     * @return true if 64-bit Linux
+     */
+    public static boolean is64BitLinux() {
+        String line, result="";
+        try {
+            Process command = Runtime.getRuntime().exec("uname -m");
+            BufferedReader in = new BufferedReader(new InputStreamReader(command.getInputStream()));
+            while ((line = in.readLine()) != null) {
+                result += (line + "\n");
+            }
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+        // 32-bit Intel Linuces, it returns i[3-6]86. For 64-bit Intel, it says x86_64
+        return (result.contains("_64"));
+    }
+
+    /**
+     * Used to check if operating system is 64-bit
+     * @return true if 64-bit operating system
+     */
+    public static boolean is64BitOS() {
+        switch (getCurrentOS()) {
+        case WINDOWS:
+            return is64BitWindows();
+        case UNIX:
+            return is64BitLinux();
+        case MACOSX:
+            return is64BitLinux();
+        case OTHER:
+            return true;
+        default:
+            return true;
+        }
+    }
+
+    /**
+     * Used to get check if JVM is 64-bit
+     * @return true if 64-bit JVM
+     */
+    public static Boolean is64BitVM() {
+        Boolean bits64;
+        if (getCurrentOS().equals(OS.WINDOWS) && JavaFinder.parseWinJavaVersion() != null) {
+            bits64 = JavaFinder.parseWinJavaVersion().is64bits;
+        } else {
+           bits64 = System.getProperty("sun.arch.data.model").equals("64");
+        }
+        return bits64;
+    }
+
 
     /**
      * Used to get the OS name for use in google analytics

--- a/src/net/ftb/util/winreg/JavaFinder.java
+++ b/src/net/ftb/util/winreg/JavaFinder.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.ftb.log.Logger;
+import net.ftb.util.OSUtils;
 
 /**
  * Windows-specific java versions finder
@@ -77,9 +78,7 @@ public class JavaFinder {
      * (or null if no matching java is found)
      ****************************************************************************/
     public static String getOSBitnessJava () {
-        String arch = System.getenv("PROCESSOR_ARCHITECTURE");
-        String wow64Arch = System.getenv("PROCESSOR_ARCHITEW6432");
-        boolean isOS64 = arch.endsWith("64") || (wow64Arch != null && wow64Arch.endsWith("64"));
+        boolean isOS64 = OSUtils.is64BitWindows();
 
         List<JavaInfo> javas = JavaFinder.findJavas();
         for (int i = 0; i < javas.size(); i++) {


### PR DESCRIPTION
Tested under linux with following OS/JVM combinations
64/64 OK
64/32 OK
32/32 OK

Checked OS X: uname -m prints i386 and x86_64 ad therefore
bitness detection code is identical with linux code
