### PR TITLE
Clean environment variables before starting new process

### DIFF
--- a/src/net/ftb/mclauncher/MinecraftLauncher.java
+++ b/src/net/ftb/mclauncher/MinecraftLauncher.java
@@ -115,6 +115,7 @@ public class MinecraftLauncher {
 
         ProcessBuilder processBuilder = new ProcessBuilder(arguments);
         processBuilder.redirectErrorStream(true);
+        OSUtils.cleanEnvVars(processBuilder.environment());
         return processBuilder.start();
     }
 

--- a/src/net/ftb/mclauncher/MinecraftLauncherNew.java
+++ b/src/net/ftb/mclauncher/MinecraftLauncherNew.java
@@ -151,6 +151,7 @@ public class MinecraftLauncherNew {
         //Logger.logInfo("Launching: " + tmp.toString());		
         builder.directory(gameDir);
         builder.redirectErrorStream(true);
+        OSUtils.cleanEnvVars(builder.environment());
         return builder.start();
     }
 

--- a/src/net/ftb/util/OSUtils.java
+++ b/src/net/ftb/util/OSUtils.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.CodeSource;
 import java.util.Enumeration;
+import java.util.Map;
 
 import lombok.Getter;
 import net.ftb.gui.LaunchFrame;
@@ -258,5 +259,13 @@ public class OSUtils {
         } catch (Exception e) {
             Logger.logError("Could not open file", e);
         }
+    }
+
+    /**
+     * Removes environment variables which may cause faulty JVM memory allocations
+     */
+    public static void cleanEnvVars(Map<String, String> environment) {
+        environment.remove("_JAVA_OPTIONS");
+        environment.remove("JAVA_TOOL_OPTIONS");
     }
 }


### PR DESCRIPTION
Removes environment variables _JAVA_OPTIONS and JAVA_TOOL_OPTIONS

RFC: Should we remove only memory allocation flags instead of removing whole 
variable? Why? Now we are giving full control to launcher and additional
parameters.
