### PR TITLE
FIXED: NPE caused by OptionsTab using locale files before the LocaleUpdater thread had finished

### DIFF
--- a/src/net/ftb/gui/LaunchFrame.java
+++ b/src/net/ftb/gui/LaunchFrame.java
@@ -155,6 +155,7 @@ public class LaunchFrame extends JFrame {
     public static boolean allowVersionChange = false;
     public static boolean doVersionBackup = false;
     public static boolean MCRunning = false;
+    public static boolean i18nLoaded = false;
     public static LauncherConsole con;
     public static String tempPass = "";
     public static Panes currentPane = Panes.MODPACK;
@@ -367,6 +368,17 @@ public class LaunchFrame extends JFrame {
 
                 LoadingDialog.setProgress(160);
 
+                /*  Delay startup until the i18n update thread completes it's work
+                 *  and populates the localeIndices, allowing OptionsTab to load
+                 *  correctly.
+                 */
+                while (!i18nLoaded) {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                    }
+                }
+                
                 LaunchFrame frame = new LaunchFrame(2);
                 instance = frame;
 

--- a/src/net/ftb/locale/LocaleUpdater.java
+++ b/src/net/ftb/locale/LocaleUpdater.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.Scanner;
 
+import net.ftb.gui.LaunchFrame;
 import net.ftb.log.Logger;
 import net.ftb.util.DownloadUtils;
 import net.ftb.util.FileUtils;
@@ -104,6 +105,7 @@ public class LocaleUpdater extends Thread {
             updateFiles();
         }
         I18N.addFiles();
+        LaunchFrame.i18nLoaded = true;
     }
 
     private void cleanUpFiles () {


### PR DESCRIPTION
Fixes the following error on non-English locales:

[ERROR] Hashtable.put:-1->LaunchFrame$1$2.uncaughtException:362: Unhandled exception in Thread[AWT-EventQueue-0,6,main]: java.lang.NullPointerException
java.util.Hashtable.put(Unknown Source)
java.util.Properties.setProperty(Unknown Source)
net.ftb.data.Settings.setLocale(Settings.java:151)
net.ftb.gui.panes.OptionsPane.saveSettingsInto(OptionsPane.java:255)
net.ftb.gui.LaunchFrame.saveSettings(LaunchFrame.java:1316)
net.ftb.gui.LaunchFrame.doLaunch(LaunchFrame.java:1635)
