### PR TITLE
Fixed new version checker to work under linux

### DIFF
--- a/src/net/ftb/data/Settings.java
+++ b/src/net/ftb/data/Settings.java
@@ -111,32 +111,17 @@ public class Settings extends Properties {
             ErrorUtils.tossError("Unable to find java; point to java executable file in Advanced Options or game will fail to launch.");
         return javaPath;
     }
-    public int[] getJavaVersion() {
-        String separator = System.getProperty("file.separator");
-        String defaultPath = null;
-        JavaInfo javaVersion;
 
-        if(OSUtils.getCurrentOS() == OS.MACOSX) {
-            javaVersion = JavaFinder.parseJavaVersion();
-
-            if(javaVersion != null && javaVersion.path != null)
-                Logger.logError(javaVersion.getMajor() + "."+ javaVersion.getMinor());
-                return new int[]{javaVersion.getMajor(), javaVersion.getMinor()};//minimum supported should NEVER be more detailed than this!!
-        } else if(OSUtils.getCurrentOS() == OS.WINDOWS) {
-            javaVersion = JavaFinder.parseJavaVersion();
-
-            if(javaVersion != null && javaVersion.path != null)
-                 return new int[]{javaVersion.getMajor(), javaVersion.getMinor()};
-        }
-        String[] version = System.getProperty("java.version").split("\\.");
-        List<Integer> tmpIJre = Lists.newArrayList();
-        for(int i = 0; i<version.length; i++){
-            tmpIJre.add(Integer.parseInt(version[i]));
-        }
-        return Ints.toArray(tmpIJre);
-
-
+    /**
+     * Returns user selected or automatically selected JVM's
+     * JavaInfo object.
+     */
+    public JavaInfo getJavaVersion() {
+        JavaInfo javaVersion = new JavaInfo(getJavaPath());
+        return javaVersion;
+        //return new int[]{javaVersion.getMajor(), javaVersion.getMinor()};
     }
+
     private String getDefaultJavaPath () {
         String separator = System.getProperty("file.separator");
         String defaultPath = null;

--- a/src/net/ftb/gui/LaunchFrame.java
+++ b/src/net/ftb/gui/LaunchFrame.java
@@ -115,6 +115,7 @@ import net.ftb.util.OSUtils;
 import net.ftb.util.OSUtils.OS;
 import net.ftb.util.StyleUtil;
 import net.ftb.util.TrackerUtils;
+import net.ftb.util.winreg.JavaInfo;
 import net.ftb.workers.AuthlibDLWorker;
 import net.ftb.workers.GameUpdateWorker;
 import net.ftb.workers.LoginWorker;
@@ -1524,10 +1525,10 @@ public class LaunchFrame extends JFrame {
     }
 
     public void doLaunch () {
-        int[] localJavaVsn = Settings.getSettings().getJavaVersion();
+        JavaInfo javaVersion = Settings.getSettings().getJavaVersion();
         int[] minSup = ModPack.getSelectedPack().getMinJRE();
         if (users.getSelectedIndex() > 1 && ModPack.getSelectedPack() != null) {
-            if (minSup.length >= 2 && localJavaVsn.length >= 2 && minSup[0] <= localJavaVsn[0] && minSup[1] <= localJavaVsn[1]){
+            if (minSup.length >= 2 && minSup[0] <= javaVersion.getMajor() && minSup[1] <= javaVersion.getMinor()){
                 Settings.getSettings().setLastPack(ModPack.getSelectedPack().getDir());
                 saveSettings();
                 doLogin(UserManager.getUsername(users.getSelectedItem().toString()), UserManager.getPassword(users.getSelectedItem().toString()));

--- a/src/net/ftb/gui/panes/OptionsPane.java
+++ b/src/net/ftb/gui/panes/OptionsPane.java
@@ -47,6 +47,7 @@ import net.ftb.log.Logger;
 import net.ftb.util.OSUtils;
 import net.ftb.util.OSUtils.OS;
 import net.ftb.util.winreg.JavaFinder;
+import net.ftb.util.winreg.JavaInfo;
 
 @SuppressWarnings("serial")
 public class OptionsPane extends JPanel implements ILauncherPane {
@@ -175,7 +176,8 @@ public class OptionsPane extends JPanel implements ILauncherPane {
         add(locale);
 
         // Dependant on vmType from earlier RAM calculations to detect 64 bit JVM
-        if(Settings.getSettings().getJavaVersion()[0] < 1 || settings.getSettings().getJavaVersion()[1] < 7){
+        JavaInfo javaVersion = Settings.getSettings().getJavaVersion();
+        if(javaVersion.getMajor() < 1 || (javaVersion.getMajor() == 1 && javaVersion.getMinor() < 7)){
             if(OSUtils.getCurrentOS().equals(OS.MACOSX)){
                 if(JavaFinder.java8Found) {//they need the jdk link
                     addUpdateJREButton(Locations.jdkMac, "DOWNLOAD_JAVAGOOD");
@@ -207,7 +209,7 @@ public class OptionsPane extends JPanel implements ILauncherPane {
                 }
             }
         }
-        else if( OSUtils.getCurrentOS().equals(OS.MACOSX) && (Settings.getSettings().getJavaVersion()[0]> 1 || settings.getSettings().getJavaVersion()[1] > 7)){
+        else if( OSUtils.getCurrentOS().equals(OS.MACOSX) && (javaVersion.getMajor() > 1 || (javaVersion.getMajor() == 1 ||  javaVersion.getMinor() > 7))){
             addUpdateJREButton(Locations.jdkMac, "DOWNLOAD_JAVAGOOD");//they need the jdk link
             addUpdateLabel("JAVA_NEW_Warning");
         }else if (!OSUtils.is64BitVM()) {//needs to use proper bit's

--- a/src/net/ftb/util/winreg/JavaFinder.java
+++ b/src/net/ftb/util/winreg/JavaFinder.java
@@ -155,7 +155,7 @@ public class JavaFinder {
             Logger.logInfo("The FTB Launcher has found the following Java versions installed:");
             for (int i = 0; i < javas.size(); i++) {
                 Logger.logInfo(javas.get(i).toString());
-                if(javas.get(i).hasJava8){
+                if(javas.get(i).isJava8()){
                     java8Found = true;
                 }
                 if(javas.get(i).supportedVersion) { 

--- a/src/net/ftb/util/winreg/JavaInfo.java
+++ b/src/net/ftb/util/winreg/JavaInfo.java
@@ -52,12 +52,21 @@ public class JavaInfo implements Comparable<JavaInfo> {
         if(OSUtils.getCurrentOS() == OS.MACOSX) {
             if (this.major == 1 && (this.minor == 7 || this.minor == 6))
                 this.supportedVersion = true;
-        }else if(this.major == 1 && this.minor == 8 ){
-            hasJava8 = true;
-            this.supportedVersion = true;
         } else {
             this.supportedVersion = true;
         }
+    }
+
+    public JavaInfo(int major, int minor) {
+        this.path = null;
+        this.major = major;
+        this.minor = minor;
+        this.revision = 0;
+        this.build = 0;
+    }
+
+    public boolean isJava8() {
+        return this.major == 1 && this.minor == 8;
     }
 
     /**


### PR DESCRIPTION
- Simplified getJavaVersion()
  Returns JavaInfo object
- LaunchFrame.java and OptionsPane.java:
  Use JavaInfo's getMajor and getMinor instead of unnamed array
- JavaInfo.java and JavaFinder.java: minor edits

RFC: Should Modpack.minJRE be JavaInfo?
     If getMinJRE() and getJavaVersion() both returns JavaInfo object then it's possible to compare those objects directly instead of comparing major and minor elements separately.
