### PR TITLE
Concurrency fixes

### DIFF
--- a/src/net/ftb/gui/LaunchFrame.java
+++ b/src/net/ftb/gui/LaunchFrame.java
@@ -51,6 +51,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.ProgressMonitor;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.WindowConstants;
@@ -622,19 +623,23 @@ public class LaunchFrame extends JFrame {
     }
 
     public static void checkDoneLoading () {
-        if (ModpacksPane.loaded) {
-            LoadingDialog.setProgress(190);
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                if (ModpacksPane.loaded) {
+                    LoadingDialog.setProgress(190);
 
-            if (MapsPane.loaded) {
-                LoadingDialog.setProgress(200);
+                    if (MapsPane.loaded) {
+                        LoadingDialog.setProgress(200);
 
-                if (TexturepackPane.loaded) {
-                    loader.setVisible(false);
-                    instance.setVisible(true);
-                    instance.toFront();
+                        if (TexturepackPane.loaded) {
+                            loader.setVisible(false);
+                            instance.setVisible(true);
+                            instance.toFront();
+                        }
+                    }
                 }
             }
-        }
+        });
     }
 
     public void setNewsIcon () {

--- a/src/net/ftb/gui/LauncherConsole.java
+++ b/src/net/ftb/gui/LauncherConsole.java
@@ -40,6 +40,7 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultCaret;
 import javax.swing.text.html.HTMLDocument;
@@ -257,7 +258,12 @@ public class LauncherConsole extends JFrame implements ILogListener {
     @Override
     public void onLogEvent (LogEntry entry) {
         if (logSource == LogSource.ALL || entry.source == logSource) {
-            addHTML(getMessage(entry));
+            final LogEntry entry_ = entry;
+            SwingUtilities.invokeLater(new Runnable() {
+                public void run() {
+                    addHTML(getMessage(entry_));
+                }
+            });
         }
     }
 }

--- a/src/net/ftb/gui/panes/MapsPane.java
+++ b/src/net/ftb/gui/panes/MapsPane.java
@@ -36,6 +36,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.HyperlinkEvent;
@@ -222,9 +223,14 @@ public class MapsPane extends JPanel implements ILauncherPane, MapListener {
 
     @Override
     public void onMapAdded (Map map) {
-        addMap(map);
-        Logger.logInfo("Adding map " + getMapNum() + " (" + map.getName() + ")");
-        updateMaps();
+        final Map map_ = map;
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                addMap(map_);
+                Logger.logInfo("Adding map " + getMapNum() + " (" + map_.getName() + ")");
+                updateMaps();
+            }
+        });
     }
 
     public static void sortMaps () {

--- a/src/net/ftb/gui/panes/ModpacksPane.java
+++ b/src/net/ftb/gui/panes/ModpacksPane.java
@@ -37,6 +37,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.HyperlinkEvent;
@@ -310,13 +311,18 @@ public class ModpacksPane extends JPanel implements ILauncherPane, ModPackListen
 
     @Override
     public void onModPackAdded (ModPack pack) {
-        addPack(pack);
-        Logger.logInfo("Adding pack " + packPanels.size() + " (" + pack.getName() + ")");
-        if (!currentPacks.isEmpty()) {
-            sortPacks();
-        } else {
-            updatePacks();
-        }
+        final ModPack pack_ = pack;
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                addPack(pack_);
+                Logger.logInfo("Adding pack " + packPanels.size() + " (" + pack_.getName() + ")");
+                if (!currentPacks.isEmpty()) {
+                    sortPacks();
+                } else {
+                    updatePacks();
+                }
+            }
+        });
     }
 
     public static void sortPacks () {

--- a/src/net/ftb/gui/panes/TexturepackPane.java
+++ b/src/net/ftb/gui/panes/TexturepackPane.java
@@ -36,6 +36,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.HyperlinkEvent;
@@ -221,9 +222,14 @@ public class TexturepackPane extends JPanel implements ILauncherPane, TexturePac
 
     @Override
     public void onTexturePackAdded (TexturePack texturePack) {
-        addTexturePack(texturePack);
-        Logger.logInfo("Adding texture pack " + getTexturePackNum() + " (" + texturePack.getName() + ")");
-        updateTexturePacks();
+        final TexturePack texturePack_ = texturePack;
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                addTexturePack(texturePack_);
+                Logger.logInfo("Adding texture pack " + getTexturePackNum() + " (" + texturePack_.getName() + ")");
+                updateTexturePacks();
+            }
+        });
     }
 
     public static void sortTexturePacks () {


### PR DESCRIPTION
Changes are done by checking Exception stack traces:
- Fixed: MapPanel, ModpacksPane and TexturePackPanel
  protect on*Add() with invokeLater()
  created unhandled exceptions

Fixed by checking thread dump:
- Fixed: LaunchFrame
  protect checkDoneLoading() with invokeLater()
  caused launcher to hang after "Adding Authlib to Classpath" message

I have not seen stack trace which is directly caused by LauncherConsole, but I hope this change will decrease NPEs and java.lang.ClassCastException at EDT
- Fixed: LauncherConsole
  protect onLogEvent() with invokaLater()
  preventive fix, no bugs seen yet

I will run more tests with http://paste.ubuntu.com/7384326/ and try to find more root causes of concurrency problems. First test runs without fixes caused 8 errors in 100 runs. With fixes 0 errors.

RFC: should those fixes use invokeLater() or invokeAndWait()?
