### PR TITLE
CHANGED: private packs

### DIFF
--- a/src/main/java/net/ftb/data/Settings.java
+++ b/src/main/java/net/ftb/data/Settings.java
@@ -294,8 +294,10 @@ public class Settings extends Properties {
         String out = "";
         String sep = "";
         for (String s : codes) {
-            out += sep + s;
-            sep = ",";
+            if (!s.isEmpty()) {
+                out += sep + s;
+                sep = ",";
+            }
         }
         setProperty("privatePacks", out);
     }

--- a/src/main/java/net/ftb/workers/ModpackLoader.java
+++ b/src/main/java/net/ftb/workers/ModpackLoader.java
@@ -57,7 +57,7 @@ public class ModpackLoader extends Thread {
     public void run () {
         //TODO ASAP thread this
         Benchmark.start("ModpackLoader");
-        for (String xmlFile : xmlFiles) {
+        xmls: for (String xmlFile : xmlFiles) {
             boolean privatePack = !xmlFile.equalsIgnoreCase(MODPACKXML) && !xmlFile.equalsIgnoreCase(THIRDPARTYXML);//this is for stuff that is stored under privatepacks on the repo
             boolean isThirdParty = !xmlFile.equalsIgnoreCase(THIRDPARTYXML);
             File modPackFile = new File(OSUtils.getCacheStorageLocation(), "ModPacks" + File.separator + xmlFile);
@@ -87,11 +87,11 @@ public class ModpackLoader extends Thread {
                     doc = AppUtils.getXML(modPackStream);
                 } catch (Exception e) {
                     Logger.logError("Exception reading modpack file", e);
-                    return;
+                    continue xmls;
                 }
                 if (doc == null) {
                     Logger.logError("Error: could not load modpack data!");
-                    return;
+                    continue xmls;
                 }
                 NodeList modPacks = doc.getElementsByTagName("modpack");
                 ArrayList<ModPack> mp = Lists.newArrayList();


### PR DESCRIPTION
- Settings: Remove empty Strings when saving private pack codes
- ModpackLoader: do not close loader if loading one xml fails
  - Try next xml file
  - fixes rare bug when xml download writes garbage to disk and AppUtils.getXML throws Exception

Will cause more errors if launcher is started without network connection. is this fix needed?
