### PR TITLE
CHANGED: minor pastebin poster & cipy to clipboard fixes

### DIFF
--- a/src/main/java/net/ftb/gui/LauncherConsole.java
+++ b/src/main/java/net/ftb/gui/LauncherConsole.java
@@ -27,6 +27,8 @@ import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 
 import javax.swing.JButton;
@@ -120,7 +122,8 @@ public class LauncherConsole extends JFrame implements ILogListener {
                     }
                 }
                 if (result == 0) {
-                    StringSelection stringSelection = new StringSelection("FTB Launcher logs:\n" + Logger.getLogs());
+                    StringSelection stringSelection = new StringSelection("FTB Launcher logs:\n" + Logger.getLogs()
+                            + "[" + new SimpleDateFormat("HH:mm:ss").format(new Date()) + "]" + " Logs copied to clipboard");
                     Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
                     clipboard.setContents(stringSelection, null);
                 }

--- a/src/main/java/net/ftb/tools/PastebinPoster.java
+++ b/src/main/java/net/ftb/tools/PastebinPoster.java
@@ -24,6 +24,8 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import net.ftb.data.Constants;
 import net.ftb.log.Logger;
@@ -48,9 +50,10 @@ public class PastebinPoster extends Thread {
             out = conn.getOutputStream();
 
             out.write(("text=" + URLEncoder.encode(Logger.getLogs(), "utf-8")
+                    + "[" + new SimpleDateFormat("HH:mm:ss").format(new Date()) + "]" + " Post created"
                     + "&private=" + URLEncoder.encode("0", "utf-8")
                     + "&title=" + URLEncoder.encode("Version: " + Constants.version, "utf-8")
-                    + "&lang=" + URLEncoder.encode("java", "utf-8")
+                    + "&lang=" + URLEncoder.encode("text", "utf-8")
                     + "&name=" + URLEncoder.encode("Launcher")).getBytes());
             out.flush();
             out.close();


### PR DESCRIPTION
Minor changes:
- Use plaintext instead of java syntax when uploading logs
- Append current time after logs when uploading or copying logs to
  clipboard

If new pastebin system has syntax which detects severity tags we should use it. Or is it possible to to write syntax for log files. @captainnana: ping

Appending current time to logs makes debugging easier because helpers know exact loading times instead of guessing what users' "I have waited long time" means.
