### PR TITLE
CHANGED: getMachineID()

### DIFF
--- a/src/main/java/net/ftb/util/OSUtils.java
+++ b/src/main/java/net/ftb/util/OSUtils.java
@@ -26,6 +26,7 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.CodeSource;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Map;
 
@@ -35,6 +36,7 @@ import lombok.Getter;
 import net.ftb.gui.LaunchFrame;
 import net.ftb.log.Logger;
 import net.ftb.util.winreg.JavaFinder;
+import net.ftb.util.winreg.RuntimeStreamer;
 
 public class OSUtils {
     private static byte[] cachedMacAddress;
@@ -56,7 +58,6 @@ public class OSUtils {
     static {
         cachedUserHome = System.getProperty("user.home");
         numCores = Runtime.getRuntime().availableProcessors();
-        hardwareID = genHardwareID();
     }
 
     /**
@@ -372,7 +373,6 @@ public class OSUtils {
     private static byte[] genHardwareID () {
         switch (getCurrentOS()) {
         case WINDOWS:
-            // TODO
             return genHardwareIDWINDOWS();
         case UNIX:
             return genHardwareIDUNIX();
@@ -384,14 +384,19 @@ public class OSUtils {
     }
     private static byte[] genHardwareIDUNIX () {
         String line;
-        try {
-            BufferedReader reader = new BufferedReader(new FileReader("/etc/machine-id"));
-            line = reader.readLine();
-        } catch (Exception e) {
-            Logger.logDebug("failed", e);
-            return new byte[]{};
+        // TODO: will add command line option or advanced option later. Use old mac address method
+        if (false) {
+            try {
+                BufferedReader reader = new BufferedReader(new FileReader("/etc/machine-id"));
+                line = reader.readLine();
+            } catch (Exception e) {
+                Logger.logDebug("failed", e);
+                return new byte[] { };
+            }
+            return line.getBytes();
+        } else {
+            return new byte[] { };
         }
-        return line.getBytes();
     }
 
     private static byte[] genHardwareIDMACOSX () {
@@ -412,18 +417,26 @@ public class OSUtils {
     }
 
     private static byte[] genHardwareIDWINDOWS() {
-        String line;
+        String processOutput;
         try {
-            Process command = Runtime.getRuntime().exec(new String[] {"wmic", "bios", "get", "serialnumber"});
-            BufferedReader in = new BufferedReader(new InputStreamReader(command.getInputStream()));
-            line = in.readLine();
-            line = in.readLine();
-            line = in.readLine();
-            Logger.logDebug(line);
-            return line.getBytes();
+            processOutput = RuntimeStreamer.execute(new String[] {"wmic", "bios", "get", "serialnumber"});
+            /*
+             * wmic's output has special formatting:
+             * SerialNumber<SP><SP><SP><CR><CR><LF>
+             * 00000000000000000<SP><CR><CR><LF><CR><CR><LF>
+             *
+             * readLin()e uses <LF>, <CR> or <CR><LF> as line ending => we need to get third line from RuntimeStreamers output
+             */
+            String line = processOutput.split("\n")[2].trim();
+            // at least VM will report serial to be 0. Does real hardware do it?
+            if (line.equals("0")) {
+                return new byte[] { };
+            } else{
+                return line.trim().getBytes();
+            }
         } catch (Exception e) {
             Logger.logDebug("failed", e);
-            return new byte[]{};
+            return new byte[] { };
         }
     }
 

--- a/src/main/java/net/ftb/util/winreg/RuntimeStreamer.java
+++ b/src/main/java/net/ftb/util/winreg/RuntimeStreamer.java
@@ -17,7 +17,7 @@ import java.io.InputStreamReader;
  * Helper class to fetch the stdout and stderr outputs from started Runtime execs
  * Modified from http://www.javaworld.com/javaworld/jw-12-2000/jw-1229-traps.html?page=4
  *****************************************************************************/
-class RuntimeStreamer extends Thread {
+public class RuntimeStreamer extends Thread {
     InputStream is;
     String lines;
 
@@ -55,6 +55,8 @@ class RuntimeStreamer extends Thread {
             RuntimeStreamer errorStreamer = new RuntimeStreamer(proc.getErrorStream());
             outputStreamer.start();
             errorStreamer.start();
+            // close process' stdin
+            proc.getOutputStream().close();
             proc.waitFor();
             return outputStreamer.contents() + errorStreamer.contents();
         } catch (Throwable t) {


### PR DESCRIPTION
- Removed usage of /etc/machine-id. Later add option to enable it
- Fixed RuntimeStreamer to send EOF to process
- Fixed launcher not working under XP. wmic never exited
- Check if bios serial number 0 and return empty => use old mac
