### PR TITLE
Reverted recent java 8 changes

### DIFF
--- a/src/main/java/net/ftb/data/CommandLineSettings.java
+++ b/src/main/java/net/ftb/data/CommandLineSettings.java
@@ -81,10 +81,6 @@ public class CommandLineSettings {
     @Getter
     private boolean disableTray = false;
 
-    @Parameter(names = {"--use-java8", "-J"}, description = "Allow use of java 8 in legacy MC versions that have known compatibility issues")
-    @Getter
-    private boolean useJava8 = false;
-
 
     public static class ValidateRequiredValue implements IParameterValidator {
         @Override

--- a/src/main/java/net/ftb/data/Settings.java
+++ b/src/main/java/net/ftb/data/Settings.java
@@ -133,21 +133,12 @@ public class Settings extends Properties {
         setProperty("betaChannel", String.valueOf(flag));
     }
 
-
-    @Deprecated
     public String getJavaPath () {
-        return getJavaPath(true);
-    }
-    /**
-     * don't use this to launch w/ use getCurrentJava(boolean canUse8)
-     * @return java's location
-     */
-    public String getJavaPath (boolean allowJava8) {
         String javaPath = getProperty("javaPath", null);
         if (javaPath == null || !new File(javaPath).isFile())
             remove("javaPath");
 
-        javaPath = getProperty("javaPath", getDefaultJavaPath(allowJava8));
+        javaPath = getProperty("javaPath", getDefaultJavaPath());
         if (javaPath == null || !new File(javaPath).isFile())
             ErrorUtils.tossError("Unable to find java; point to java executable file in Advanced Options or game will fail to launch.");
         return javaPath;
@@ -157,52 +148,27 @@ public class Settings extends Properties {
     * Returns user selected or automatically selected JVM's
     * JavaInfo object.
     */
-    @Deprecated //use the boolean version instead
     public JavaInfo getCurrentJava () {
-        return getCurrentJava(true);
-    }
-
-    /**
-     * Returns user selected or automatically selected JVM's
-     * JavaInfo object.
-     */
-    public JavaInfo getCurrentJava(boolean canuse8) {
         if (currentJava == null) {
             try {
-                currentJava = new JavaInfo(getJavaPath(true));
+                currentJava = new JavaInfo(getJavaPath());
             } catch (Exception e) {
                 Logger.logError("Error while creating JavaInfo", e);
             }
         }
-        if(!canuse8 && currentJava.isJava8()) {
-            JavaInfo java = null;
-            try {
-                // this should not never fail
-                java = new JavaInfo(getJavaPath(false));
-            } catch (Exception e) {
-                Logger.logError("Error while creating JavaInfo", e);
-            }
-            if (java != null)
-                return java;
-        }
-
         return currentJava;
     }
 
-    @Deprecated
     public String getDefaultJavaPath () {
-        return getDefaultJavaPath(true);
-    }
-    public String getDefaultJavaPath (boolean allowJava8) {
         JavaInfo javaVersion;
 
         if (OSUtils.getCurrentOS() == OS.MACOSX) {
-            javaVersion = JavaFinder.parseJavaVersion(allowJava8);
+            javaVersion = JavaFinder.parseJavaVersion();
 
             if (javaVersion != null && javaVersion.path != null)
                 return javaVersion.path;
         } else if (OSUtils.getCurrentOS() == OS.WINDOWS) {
-            javaVersion = JavaFinder.parseJavaVersion(allowJava8);
+            javaVersion = JavaFinder.parseJavaVersion();
 
             if (javaVersion != null && javaVersion.path != null)
                 return javaVersion.path.replace(".exe", "w.exe");

--- a/src/main/java/net/ftb/gui/LaunchFrame.java
+++ b/src/main/java/net/ftb/gui/LaunchFrame.java
@@ -43,14 +43,7 @@ import com.google.common.eventbus.Subscribe;
 
 import lombok.Getter;
 import lombok.Setter;
-import net.ftb.data.CommandLineSettings;
-import net.ftb.data.Constants;
-import net.ftb.data.LauncherStyle;
-import net.ftb.data.LoginResponse;
-import net.ftb.data.Map;
-import net.ftb.data.ModPack;
-import net.ftb.data.Settings;
-import net.ftb.data.UserManager;
+import net.ftb.data.*;
 import net.ftb.download.Locations;
 import net.ftb.events.EnableObjectsEvent;
 import net.ftb.gui.dialogs.LoadingDialog;
@@ -829,19 +822,8 @@ public class LaunchFrame extends JFrame {
     }
 
     public void doLaunch () {
+        JavaInfo java = Settings.getSettings().getCurrentJava();
         ModPack pack = ModPack.getSelectedPack();
-
-        // compare mc version and jvm version. Stop startup if no valid JVM found for 1.6/1.7.2 packs
-        String mcversion = pack.getMcVersion(Settings.getSettings().getPackVer(pack.getDir()));
-        boolean java8Usable = false;
-        //if(mcversion.startsWith("1.7.10") || mcversion.startsWith("1.8")|| pack.getDir().equals("mojang_vanilla") || CommandLineSettings.getSettings().isUseJava8()) //TODO re-add this if java 8 ever has issues again
-            java8Usable = true;
-        JavaInfo java = Settings.getSettings().getCurrentJava(java8Usable);
-        if ( (!java8Usable && java == null) || (!java8Usable && OSUtils.getCurrentOS()==OS.UNIX && java.isJava8())) {
-            ErrorUtils.tossError("Your system only has Java 8 installed which is incompatible with this version of minecraft. Please download Java 7 using the link in the options tab");
-            return;
-        }
-
         // check launcher version
         if (ModPack.getSelectedPack().getMinLaunchSpec() > Constants.buildNumber) {
             ErrorUtils.tossError("Please update your launcher in order to launch this pack! This can be done by restarting your launcher, an update dialog will pop up.");

--- a/src/main/java/net/ftb/gui/panes/OptionsPane.java
+++ b/src/main/java/net/ftb/gui/panes/OptionsPane.java
@@ -309,9 +309,7 @@ public class OptionsPane extends JPanel implements ILauncherPane {
         remove(btnInstallJava);
         // Dependant on vmType from earlier RAM calculations to detect 64 bit JVM
         JavaInfo java = Settings.getSettings().getCurrentJava();
-        JavaInfo javaBackup = Settings.getSettings().getCurrentJava(false);
-
-        // offer java 7 is java 6 or older is detected
+        // offer java 7 if java 6 or older is detected
         if(java.getMajor() < 1 || (java.getMajor() == 1 && java.getMinor() < 7)){
             offerJava7("JAVA_OLD_Warning");
         }
@@ -321,10 +319,6 @@ public class OptionsPane extends JPanel implements ILauncherPane {
             addUpdateJREButton(Locations.jdkMac, "DOWNLOAD_JAVAGOOD");//they need the jdk link
             addUpdateLabel("JAVA_NEW_Warning");
         }
-        else if(javaBackup == null && java.isJava8() || (OSUtils.getCurrentOS() == OS.UNIX && java.isJava8())) {
-            offerJava7("JAVA_NEW_Warning");
-        }
-
         // offer 64-bit java if 32-bit java detected in 64-bit OS
         else if (!Settings.getSettings().getCurrentJava().is64bits) {//needs to use proper bit's
             addUpdateLabel("JAVA_32BIT_WARNING");

--- a/src/main/java/net/ftb/minecraft/MCInstaller.java
+++ b/src/main/java/net/ftb/minecraft/MCInstaller.java
@@ -38,7 +38,6 @@ import net.ftb.log.StreamLogger;
 import net.ftb.main.Main;
 import net.ftb.tools.ProcessMonitor;
 import net.ftb.util.*;
-import net.ftb.util.winreg.JavaInfo;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -379,12 +378,8 @@ public class MCInstaller {
             for (Library lib : base.getLibraries()) {
                 classpath.add(new File(libDir, lib.getPath()));
             }
-            boolean java8Usable = false;
-            //if(packmcversion.startsWith("1.7.10") || packmcversion.startsWith("1.8") || pack.getDir().equals("mojang_vanilla") ||  CommandLineSettings.getSettings().isUseJava8())//TODO re-add this if java 8 ever has issues again
-                java8Usable = true;
-            JavaInfo java = Settings.getSettings().getCurrentJava(java8Usable);
 
-            Process minecraftProcess = MCLauncher.launchMinecraft(java.path, gameFolder, assetDir, natDir, classpath,
+            Process minecraftProcess = MCLauncher.launchMinecraft(Settings.getSettings().getJavaPath(), gameFolder, assetDir, natDir, classpath,
                     packjson.mainClass != null ? packjson.mainClass : base.mainClass, packjson.minecraftArguments != null ? packjson.minecraftArguments : base.minecraftArguments,
                     packjson.assets != null ? packjson.assets : base.getAssets(), Settings.getSettings().getRamMax(), pack.getMaxPermSize(), pack.getMcVersion(packVer), resp.getAuth(), isLegacy);
             LaunchFrame.MCRunning = true;

--- a/src/main/java/net/ftb/util/winreg/JavaFinder.java
+++ b/src/main/java/net/ftb/util/winreg/JavaFinder.java
@@ -22,9 +22,6 @@ import net.ftb.util.OSUtils.OS;
  *****************************************************************************/
 public class JavaFinder {
     public static boolean java8Found = false;
-    private static JavaInfo preferred;
-    private static JavaInfo backup;
-
     /**
      * @return: A list of javaExec paths found under this registry key (rooted at HKEY_LOCAL_MACHINE)
      * @param wow64  0 for standard registry access (32-bits for 32-bit app, 64-bits for 64-bits app)
@@ -155,14 +152,12 @@ public class JavaFinder {
         return null;
     }
 
+    private static JavaInfo preferred;
+
+    /**
+     * Standalone testing - lists all Javas in the system
+     ****************************************************************************/
     public static JavaInfo parseJavaVersion () {
-        // TODO: add command line argument to control this
-        return parseJavaVersion(true);
-    }
-        /**
-         * Standalone testing - lists all Javas in the system
-         ****************************************************************************/
-    public static JavaInfo parseJavaVersion (boolean canUseJava8) {
         if (preferred == null) {
             List<JavaInfo> javas = JavaFinder.findJavas();
             List<JavaInfo> java32 = Lists.newArrayList();
@@ -175,7 +170,7 @@ public class JavaFinder {
                     java8Found = true;
                 }
                 if (java.supportedVersion) {
-                    if (preferred == null)
+                    if (preferred == null && java != null)
                         preferred = java;
                     if (java.is64bits)
                         java64.add(java);
@@ -188,37 +183,21 @@ public class JavaFinder {
                 for (JavaInfo aJava64 : java64) {
                     if (!preferred.is64bits || aJava64.compareTo(preferred) == 1)
                         preferred = aJava64;
-                    if (backup == null && !aJava64.isJava8())
-                        backup = aJava64;
-                    if(backup != null && !aJava64.isJava8() && aJava64.compareTo(backup) == 1)
-                        backup = aJava64;
                 }
             }
-
             if (java32.size() > 0) {
                 for (JavaInfo aJava32 : java32) {
                     if (!preferred.is64bits && aJava32.compareTo(preferred) == 1)
                         preferred = aJava32;
-                    if (backup == null && !aJava32.isJava8())
-                        backup = aJava32;
-                    if(backup != null && !aJava32.isJava8() && aJava32.compareTo(backup) == 1)
-                        backup = aJava32;
-
                 }
             }
-            Logger.logDebug("Preferred: " + String.valueOf(preferred));
-            Logger.logDebug("Backup(java8 excluded): " + String.valueOf(backup));
+            Logger.logInfo("Preferred: " + String.valueOf(preferred));
         }
 
         if (preferred != null) {
-            if (backup != null && preferred.isJava8() && !canUseJava8) {
-                return backup;
-            } else if (backup == null && preferred.isJava8() && !canUseJava8) {
-                return null;
-            } else {
-                return preferred;
-            }
+            return preferred;
         } else {
+            Logger.logError("No Java versions found!");
             return null;
         }
     }


### PR DESCRIPTION
- Reverted recent java 8 changes except legacyjavafixer injection
- Code was bad, introduced new bugs, not really future-proof etc
- Still unsolved: what if 1.6 or older packs have mods which does
  not work with java 8?
