### PR TITLE
FIXED: abort launching and show error messsage if pack unzipping fails

### DIFF
--- a/src/main/java/net/ftb/tools/ModManager.java
+++ b/src/main/java/net/ftb/tools/ModManager.java
@@ -254,7 +254,10 @@ public class ModManager extends JDialog {
                     }
 
                     Logger.logDebug("Extracting pack.");
-                    FTBFileUtils.extractZipTo(baseDynamic.getPath() + sep + modPackName, baseDynamic.getPath());
+                    if (!FTBFileUtils.extractZipTo(baseDynamic.getPath() + sep + modPackName, baseDynamic.getPath())) {
+                        ErrorUtils.tossError("Error downloading modpack!!!");
+                        return false;
+                    }
                     if (pack.getBundledMap() && saveExists) {
                         try {
                             if (new File(installPath, dir + "/minecraft/saves").exists() && new File(installPath, dir + "/minecraft/saves.ftbtmp").exists()) {

--- a/src/main/java/net/ftb/util/FTBFileUtils.java
+++ b/src/main/java/net/ftb/util/FTBFileUtils.java
@@ -118,7 +118,9 @@ public class FTBFileUtils {
      * @param zipLocation - the location of the zip to be extracted
      * @param outputLocation - location to extract to
      */
-    public static void extractZipTo (String zipLocation, String outputLocation) {
+    public static boolean extractZipTo (String zipLocation, String outputLocation) {
+        boolean success = true;
+        boolean backupSuccess = true;
         ZipInputStream zipinputstream = null;
         try {
             byte[] buf = new byte[1024];
@@ -139,17 +141,23 @@ public class FTBFileUtils {
                 zipentry = zipinputstream.getNextEntry();
             }
         } catch (Exception e) {
+            success = false;
             Logger.logError("Error while extracting zip", e);
-            backupExtract(zipLocation, outputLocation);
+            backupSuccess = backupExtract(zipLocation, outputLocation);
         } finally {
             try {
                 zipinputstream.close();
             } catch (IOException e) {
             }
         }
+        if (!success) {
+            return backupSuccess;
+        }
+        return true;
     }
 
-    public static void backupExtract (String zipLocation, String outputLocation) {
+    public static boolean backupExtract (String zipLocation, String outputLocation) {
+        boolean success = true;
         Logger.logInfo("Extracting (Backup way)");
         byte[] buffer = new byte[1024];
         ZipInputStream zis = null;
@@ -177,6 +185,7 @@ public class FTBFileUtils {
             }
         } catch (IOException ex) {
             Logger.logError("Error while extracting zip", ex);
+            success = false;
         } finally {
             try {
                 zis.closeEntry();
@@ -184,6 +193,7 @@ public class FTBFileUtils {
             } catch (IOException e) {
             }
         }
+        return success;
     }
 
     /**


### PR DESCRIPTION
Tested with currently broken Dark Trilogy pack .zips
