### PR TITLE
Additional check for non-GNOME desktop environments

### DIFF
--- a/src/main/java/net/ftb/util/OSUtils.java
+++ b/src/main/java/net/ftb/util/OSUtils.java
@@ -480,7 +480,7 @@ public class OSUtils {
      */
     public static void browse (String url) {
         try {
-            if (Desktop.isDesktopSupported()) {
+            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Action.BROWSE)) {
                 Desktop.getDesktop().browse(new URI(url));
             } else if (getCurrentOS() == OS.UNIX && (new File("/usr/bin/xdg-open").exists() || new File("/usr/local/bin/xdg-open").exists())) {
                 // Work-around to support non-GNOME Linux desktop environments with xdg-open installed
@@ -502,7 +502,7 @@ public class OSUtils {
             return;
         }
         try {
-            if (Desktop.isDesktopSupported()) {
+            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Action.OPEN)) {
                 Desktop.getDesktop().open(path);
             } else if (getCurrentOS() == OS.UNIX) {
                 // Work-around to support non-GNOME Linux desktop environments with xdg-open installed


### PR DESCRIPTION
I'm using KDE, and doing Desktop.browse(URI) on it throws an UnsupportedOperationException. This adds an additional check for it. Fixes #900.