### PR TITLE
FIXED: authlibHelper

### DIFF
--- a/src/main/java/net/ftb/data/Settings.java
+++ b/src/main/java/net/ftb/data/Settings.java
@@ -36,11 +36,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.sql.Date;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
+import java.util.*;
 import java.util.List;
-import java.util.Properties;
 
 @SuppressWarnings("serial")
 public class Settings extends Properties {

--- a/src/main/java/net/ftb/minecraft/MCLauncher.java
+++ b/src/main/java/net/ftb/minecraft/MCLauncher.java
@@ -40,6 +40,7 @@ import net.ftb.util.FTBFileUtils;
 import net.ftb.util.OSUtils;
 import net.ftb.util.Parallel;
 import net.ftb.util.TrackerUtils;
+import net.ftb.util.winreg.JavaVersion;
 
 import java.awt.*;
 import java.io.File;
@@ -88,27 +89,29 @@ public class MCLauncher {
 
         setMemory(arguments, rmax);
 
-        if (OSUtils.getCurrentOS().equals(OSUtils.OS.WINDOWS)) {
-            if (!OSUtils.is64BitWindows()) {
-                if (maxPermSize == null || maxPermSize.isEmpty()) {
-                    if (OSUtils.getOSTotalMemory() > 2046) {
-                        maxPermSize = "192m";
-                        Logger.logInfo("Defaulting PermSize to 192m");
-                    } else {
-                        maxPermSize = "128m";
-                        Logger.logInfo("Defaulting PermSize to 128m");
+        if (Settings.getSettings().getCurrentJava().isOlder(JavaVersion.createJavaVersion("1.8.0"))) {
+            if (OSUtils.getCurrentOS().equals(OSUtils.OS.WINDOWS)) {
+                if (!OSUtils.is64BitWindows()) {
+                    if (maxPermSize == null || maxPermSize.isEmpty()) {
+                        if (OSUtils.getOSTotalMemory() > 2046) {
+                            maxPermSize = "192m";
+                            Logger.logInfo("Defaulting PermSize to 192m");
+                        } else {
+                            maxPermSize = "128m";
+                            Logger.logInfo("Defaulting PermSize to 128m");
+                        }
                     }
                 }
             }
-        }
 
-        if (maxPermSize == null || maxPermSize.isEmpty()) {
-            // 64-bit or Non-Windows
-            maxPermSize = "256m";
-            Logger.logInfo("Defaulting PermSize to 256m");
-        }
+            if (maxPermSize == null || maxPermSize.isEmpty()) {
+                // 64-bit or Non-Windows
+                maxPermSize = "256m";
+                Logger.logInfo("Defaulting PermSize to 256m");
+            }
 
-        arguments.add("-XX:PermSize=" + maxPermSize);
+            arguments.add("-XX:PermSize=" + maxPermSize);
+        }
         arguments.add("-Djava.library.path=" + nativesDir.getAbsolutePath());
         arguments.add("-Dorg.lwjgl.librarypath=" + nativesDir.getAbsolutePath());
         arguments.add("-Dnet.java.games.input.librarypath=" + nativesDir.getAbsolutePath());
@@ -143,8 +146,9 @@ public class MCLauncher {
             }
         }
         if (Settings.getSettings().getOptJavaArgs()) {
-            Logger.logInfo("Adding Optimization Arguments");
-            Collections.addAll(arguments, "-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CICompilerCountPerCPU -XX:+TieredCompilation".split("\\s+"));
+            String optArgs = "-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CICompilerCountPerCPU -XX:+TieredCompilation";
+            Logger.logInfo("Adding Optimization Arguments: " + optArgs);
+            Collections.addAll(arguments, optArgs.split("\\s+"));
         }
 
         //Undocumented environment variable to control JVM

--- a/src/main/java/net/ftb/workers/AuthlibHelper.java
+++ b/src/main/java/net/ftb/workers/AuthlibHelper.java
@@ -41,6 +41,7 @@ import net.ftb.gui.LaunchFrame;
 import net.ftb.gui.dialogs.PasswordDialog;
 import net.ftb.log.Logger;
 import net.ftb.util.ErrorUtils;
+import net.ftb.util.OSUtils;
 
 import java.io.File;
 import java.net.Proxy;
@@ -57,7 +58,8 @@ public class AuthlibHelper {
         boolean hasMojangData = false;
         boolean hasPassword = false;
         GameProfile selectedProfile = null;
-        YggdrasilUserAuthentication authentication = (YggdrasilUserAuthentication) new YggdrasilAuthenticationService(Proxy.NO_PROXY, "1").createUserAuthentication(Agent.MINECRAFT);
+        YggdrasilUserAuthentication authentication = (YggdrasilUserAuthentication) new YggdrasilAuthenticationService(Proxy.NO_PROXY, OSUtils.getClientToken().toString()).createUserAuthentication(
+                Agent.MINECRAFT);
         if (user != null) {
             Logger.logDebug(user.contains("@") ? "Email address given" : "Username given" + " Not 100% sure, mojangdata might contain different username");
             Logger.logInfo("Beginning authlib authentication attempt");


### PR DESCRIPTION
 * Added random UUID for client instances
 * Pass client UUID to YggdrasilAuthenticationService

 * User's client won't anymore share common UUID
   => Access token won't be invalidated with other client instances
 * Password not saved, auth token saved combination works now
   if user has multiple launcher instances