### PR TITLE
Added configuration by environment variables

### DIFF
--- a/src/main/java/net/ftb/util/OSUtils.java
+++ b/src/main/java/net/ftb/util/OSUtils.java
@@ -113,6 +113,12 @@ public class OSUtils {
         if (CommandLineSettings.getSettings().getDynamicDir() != null && !CommandLineSettings.getSettings().getDynamicDir().isEmpty()) {
             return CommandLineSettings.getSettings().getDynamicDir();
         }
+
+        String sysenv = System.getProperty("FTB_DYN_STORAGE_LOCATION");
+        if(!sysenv.equals("")){
+          return sysenv;
+        }
+
         switch (getCurrentOS()) {
         case WINDOWS:
             return System.getenv("APPDATA") + "/ftblauncher/";
@@ -135,6 +141,12 @@ public class OSUtils {
         if (CommandLineSettings.getSettings().getCacheDir() != null && !CommandLineSettings.getSettings().getCacheDir().isEmpty()) {
             return CommandLineSettings.getSettings().getCacheDir();
         }
+
+        String sysenv = System.getProperty("FTB_CACHE_STORAGE_LOCATION");
+        if(!sysenv.equals("")){
+          return sysenv;
+        }
+        
         switch (getCurrentOS()) {
         case WINDOWS:
             if (System.getenv("LOCALAPPDATA") != null && System.getenv("LOCALAPPDATA").length() > 5) {


### PR DESCRIPTION
Added the ability to set the dynamic storage location and cache storage location by way of two environment variables, FTB_DYN_STORAGE_LOCATION and FTB_CACHE_STORAGE_LOCATION respectively

I'd like to see the ability to change more default configuration through environment variables, for those of us who's installations aren't arranged in the usual way.