### PR TITLE
Logging performance improvements for #960

### DIFF
--- a/src/main/java/net/ftb/log/LogEntry.java
+++ b/src/main/java/net/ftb/log/LogEntry.java
@@ -26,7 +26,6 @@ public class LogEntry {
     private Throwable cause;
     private String location;
     private final Date date;
-    private String[] messageCache;
     private static final ThreadLocal<SimpleDateFormat> dateFormat = new ThreadLocal<SimpleDateFormat>() {
         @Override
         protected SimpleDateFormat initialValue () {
@@ -96,21 +95,17 @@ public class LogEntry {
     }
 
     public String toString (LogType type) {
-        if (messageCache != null && messageCache[type.ordinal()] != null) {
-            return messageCache[type.ordinal()];
-        }
         StringBuilder entryMessage = new StringBuilder();
         if (source != LogSource.EXTERNAL) {
-            if (type.includes(LogType.EXTENDED)) {
+            boolean extended = type.includes(LogType.EXTENDED);
+            if (extended) {
                 entryMessage.append("[").append(dateFormat.get().format(date)).append("] ");
-            }
-            if (type.includes(LogType.EXTENDED)) {
                 entryMessage.append("[").append(level).append("] ");
             }
             if (type.includes(LogType.DEBUG)) {
                 entryMessage.append("in ").append(source).append(" ");
             }
-            if (location != null && type.includes(LogType.EXTENDED)) {
+            if (extended && location != null) {
                 entryMessage.append(location).append(": ");
             }
         }
@@ -123,14 +118,8 @@ public class LogEntry {
                 }
             }
         }
-        String message = entryMessage.toString();
 
-        if (messageCache == null) {
-            messageCache = new String[LogType.indexCount];
-        }
-        messageCache[type.ordinal()] = message;
-
-        return message;
+        return entryMessage.toString();
     }
 
     private static String getLocation (Throwable t) {

--- a/src/main/java/net/ftb/log/LogEntry.java
+++ b/src/main/java/net/ftb/log/LogEntry.java
@@ -16,11 +16,8 @@
  */
 package net.ftb.log;
 
-import com.google.common.collect.Maps;
-
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Map;
 
 public class LogEntry {
     private String message = "";
@@ -28,14 +25,24 @@ public class LogEntry {
     public LogSource source = LogSource.LAUNCHER;
     private Throwable cause;
     private String location;
-    private final String dateString;
-    private final Map<LogType, String> messageCache = Maps.newHashMap();
-    private static final String dateFormatString = "HH:mm:ss";
+    private final Date date;
+    private String[] messageCache;
+    private static final ThreadLocal<SimpleDateFormat> dateFormat = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue () {
+            return new SimpleDateFormat("HH:mm:ss");
+        }
+    };
 
     public LogEntry () {
-        Date date = new Date();
-        this.dateString = new SimpleDateFormat(dateFormatString).format(date);
-        this.location = getLocation(cause);
+        this(true);
+    }
+
+    public LogEntry (boolean setLocation) {
+        this.date = new Date();
+        if (setLocation) {
+            this.location = getLocation(cause);
+        }
     }
 
     public LogEntry message (String message) {
@@ -89,13 +96,13 @@ public class LogEntry {
     }
 
     public String toString (LogType type) {
-        if (messageCache.containsKey(type)) {
-            return messageCache.get(type);
+        if (messageCache != null && messageCache[type.ordinal()] != null) {
+            return messageCache[type.ordinal()];
         }
         StringBuilder entryMessage = new StringBuilder();
         if (source != LogSource.EXTERNAL) {
             if (type.includes(LogType.EXTENDED)) {
-                entryMessage.append("[").append(dateString).append("] ");
+                entryMessage.append("[").append(dateFormat.get().format(date)).append("] ");
             }
             if (type.includes(LogType.EXTENDED)) {
                 entryMessage.append("[").append(level).append("] ");
@@ -117,7 +124,12 @@ public class LogEntry {
             }
         }
         String message = entryMessage.toString();
-        messageCache.put(type, message);
+
+        if (messageCache == null) {
+            messageCache = new String[LogType.indexCount];
+        }
+        messageCache[type.ordinal()] = message;
+
         return message;
     }
 

--- a/src/main/java/net/ftb/log/LogType.java
+++ b/src/main/java/net/ftb/log/LogType.java
@@ -18,13 +18,18 @@ package net.ftb.log;
 
 public enum LogType {
     DEBUG, EXTENDED, MINIMAL;
-    public static final int indexCount = LogType.values().length;
+
+    private final String name;
+
+    LogType () {
+        name = name().substring(0, 1) + name().substring(1).toLowerCase();
+    }
 
     public boolean includes (LogType other) {
-        return other.compareTo(this) >= 0;
+        return (other.ordinal() - this.ordinal()) >= 0;
     }
 
     public String toString () {
-        return name().substring(0, 1) + name().substring(1).toLowerCase();
+        return name;
     }
 }

--- a/src/main/java/net/ftb/log/LogType.java
+++ b/src/main/java/net/ftb/log/LogType.java
@@ -18,6 +18,7 @@ package net.ftb.log;
 
 public enum LogType {
     DEBUG, EXTENDED, MINIMAL;
+    public static final int indexCount = LogType.values().length;
 
     public boolean includes (LogType other) {
         return other.compareTo(this) >= 0;

--- a/src/main/java/net/ftb/log/LogWriter.java
+++ b/src/main/java/net/ftb/log/LogWriter.java
@@ -31,6 +31,16 @@ public class LogWriter implements ILogListener {
         this.logWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(logFile), "UTF-8"));
         this.logWriter.write(logFile + ": written by FTB Launcher" + System.getProperty("line.separator"));
         this.logWriter.flush();
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                try {
+                    logWriter.flush();
+                } catch (IOException ignored) {
+                    // ignored
+                }
+            }
+        });
     }
 
     @Override
@@ -38,7 +48,6 @@ public class LogWriter implements ILogListener {
         if (entry.source == source) {
             try {
                 logWriter.write(entry.toString(LogType.EXTENDED) + System.getProperty("line.separator"));
-                logWriter.flush();
             } catch (IOException e) {
                 // We probably do not want to trigger new errors
                 // How can we notify user? Is notify needed?

--- a/src/main/resources/i18n/enUS
+++ b/src/main/resources/i18n/enUS
@@ -20,6 +20,7 @@ CONSOLE_COPYCLIP = Copy to clipboard
 CONSOLE_CLIP_CONFIRM = Do you want to copy the full log to your clipboard?
 CONSOLE_PASTE = Upload Log
 CONSOLE_SUPPORT = Need support? Click me!
+CONSOLE_TOGGLE_LIMIT = Limit Logs
 
 # Map Tab
 INSTALL_MAP = Install Map


### PR DESCRIPTION
See #960

LogEntry changes:
Don't create new SimpleDateFormat instance in constructor. Don't set location of log entries from stream source (always same, not useufl and slow as new Throwable() is quite slow). Use array instead of map for cache of log entry messages.

Logger changes:
Use ConcurrentLinkedQueue instead of Vector to avoid need to copy entire collection

LogWriter:
Don't flush on every write (sorry, past me did this, don't know why)

StreamLogger:
Use java's built-in BufferedReader to read each line instead of doing it manually

LogType:
Add indexes for use in LogEntry cache

LauncherConsole:
Compatibility with Logger change
Add log entries to document in chunks
refreshConsole() builds text in new Document, then sets the textarea's document to that document after it is done

Bumped Gradle version to 2.10:
Gradle 2.4 freezes on my machine, not sure why.
