### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/src/main/java/net/ftb/data/Map.java
+++ b/src/main/java/net/ftb/data/Map.java
@@ -76,7 +76,7 @@ public class Map {
      * Used to get the List of maps
      * @return - the array containing all the maps
      */
-    public static ArrayList<Map> getMapArray () {
+    public static List<Map> getMapArray () {
         return maps;
     }
 

--- a/src/main/java/net/ftb/data/ModPack.java
+++ b/src/main/java/net/ftb/data/ModPack.java
@@ -41,6 +41,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
 
 public class ModPack {
     private String name, author, version, url, dir, mcVersion, serverUrl, logoName, imageName, info, animation, maxPermSize, sep = File.separator, xml;
@@ -63,7 +65,7 @@ public class ModPack {
      * @return map of <String packversion, String MCVersion>
      */
     @Getter
-    private HashMap<String, String> customMCVersions = Maps.newHashMap();
+    private Map<String, String> customMCVersions = Maps.newHashMap();
 
     /**
      * Loads the modpack.xml and adds it to the modpack array in this class
@@ -102,7 +104,7 @@ public class ModPack {
      * Adds modpack to the modpacks array
      * @param packs_ - an array list of ModPack instances
      */
-    public static void addPacks (ArrayList<ModPack> packs_) {
+    public static void addPacks (List<ModPack> packs_) {
         synchronized (packs) {
             for (ModPack p : packs_) {
                 packs.add(p);
@@ -127,7 +129,7 @@ public class ModPack {
      * Used to get the List of modpacks
      * @return - the array containing all the modpacks
      */
-    public static ArrayList<ModPack> getPackArray () {
+    public static List<ModPack> getPackArray () {
         return packs;
     }
 

--- a/src/main/java/net/ftb/data/Settings.java
+++ b/src/main/java/net/ftb/data/Settings.java
@@ -280,7 +280,7 @@ public class Settings extends Properties {
             return;
         }
         if (getProperty("privatePacks") != null) {
-            ArrayList<String> packList = getPrivatePacks();
+            List<String> packList = getPrivatePacks();
             if (!packList.contains(code)) {
                 packList.add(code);
                 setPrivatePacks(packList);
@@ -291,7 +291,7 @@ public class Settings extends Properties {
     }
 
     public void removePrivatePack (String code) {
-        ArrayList<String> codes = getPrivatePacks();
+        List<String> codes = getPrivatePacks();
         if (codes.contains(code)) {
             codes.remove(code);
         }

--- a/src/main/java/net/ftb/data/TexturePack.java
+++ b/src/main/java/net/ftb/data/TexturePack.java
@@ -53,7 +53,7 @@ public class TexturePack {
     @Getter
     private int index;
     @Getter
-    private final static ArrayList<TexturePack> texturePackArray = Lists.newArrayList();
+    private final static List<TexturePack> texturePackArray = Lists.newArrayList();
     private static List<TexturePackListener> listeners = Lists.newArrayList();
 
     public static void addListener (TexturePackListener listener) {

--- a/src/main/java/net/ftb/data/UserManager.java
+++ b/src/main/java/net/ftb/data/UserManager.java
@@ -34,9 +34,10 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.StreamCorruptedException;
 import java.util.ArrayList;
+import java.util.List;
 
 public class UserManager {
-    public final static ArrayList<User> _users = new ArrayList<User>();
+    public final static List<User> _users = new ArrayList<User>();
     private File _file;
     private File _oldFile;
 
@@ -148,7 +149,7 @@ public class UserManager {
         _users.add(new User(username, password, name));
     }
 
-    public static ArrayList<String> getUsernames () {
+    public static List<String> getUsernames () {
         ArrayList<String> ret = new ArrayList<String>();
         for (User user : _users) {
             ret.add(user.getName());

--- a/src/main/java/net/ftb/download/Locations.java
+++ b/src/main/java/net/ftb/download/Locations.java
@@ -19,6 +19,7 @@ package net.ftb.download;
 import com.google.common.collect.Maps;
 
 import java.util.HashMap;
+import java.util.Map;
 
 //Class used for storage of various constants & location information used by various downloading processes
 public class Locations {
@@ -55,7 +56,7 @@ public class Locations {
 
     //maps of JSON pairs of the primary/backup download servers
     public static HashMap<String, String> downloadServers = Maps.newHashMap();
-    public static HashMap<String, String> backupServers = Maps.newHashMap();
+    public static Map<String, String> backupServers = Maps.newHashMap();
 
     //Oracle Java Locations
     public static final String java64Win = "http://javadl.sun.com/webapps/download/AutoDL?BundleId=107100";

--- a/src/main/java/net/ftb/events/PackChangeEvent.java
+++ b/src/main/java/net/ftb/events/PackChangeEvent.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 import net.ftb.data.ModPack;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class PackChangeEvent implements ILauncherEvent {
     public enum TYPE {
@@ -37,7 +38,7 @@ public class PackChangeEvent implements ILauncherEvent {
      * make sure to null check when using getter !!!!
      */
     @Getter
-    private ArrayList<ModPack> packs;
+    private List<ModPack> packs;
 
     /**
      *

--- a/src/main/java/net/ftb/gui/dialogs/MapFilterDialog.java
+++ b/src/main/java/net/ftb/gui/dialogs/MapFilterDialog.java
@@ -29,6 +29,7 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.*;
 
@@ -55,8 +56,8 @@ public class MapFilterDialog extends JDialog {
 
         this.pane = instance;
 
-        ArrayList<String> packs = Lists.newArrayList();
-        final ArrayList<String> packsNoVersion = Lists.newArrayList();
+        List<String> packs = Lists.newArrayList();
+        final List<String> packsNoVersion = Lists.newArrayList();
         packs.add(I18N.getLocaleString("MAIN_ALL"));
         packsNoVersion.add(I18N.getLocaleString("MAIN_ALL"));
 

--- a/src/main/java/net/ftb/gui/dialogs/ModPackFilterDialog.java
+++ b/src/main/java/net/ftb/gui/dialogs/ModPackFilterDialog.java
@@ -27,7 +27,7 @@ import net.miginfocom.swing.MigLayout;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.*;
 
@@ -52,7 +52,7 @@ public class ModPackFilterDialog extends JDialog {
 
         this.pane = instance;
 
-        ArrayList<String> mcVersions = Lists.newArrayList();
+        List<String> mcVersions = Lists.newArrayList();
         mcVersion.addItem(I18N.getLocaleString("MAIN_ALL"));
         mcVersions.add(I18N.getLocaleString("MAIN_ALL"));
         for (ModPack pack : ModPack.getPackArray()) {

--- a/src/main/java/net/ftb/gui/dialogs/PrivatePackDialog.java
+++ b/src/main/java/net/ftb/gui/dialogs/PrivatePackDialog.java
@@ -36,6 +36,7 @@ import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.*;
 
@@ -97,7 +98,7 @@ public class PrivatePackDialog extends JDialog {
         remove.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed (ActionEvent arg0) {
-                ArrayList<String> codes = Settings.getSettings().getPrivatePacks();
+                List<String> codes = Settings.getSettings().getPrivatePacks();
                 String toRemove = "";
                 for (String s : codes) {
                     if (s.equalsIgnoreCase(modpackName.getText())) {

--- a/src/main/java/net/ftb/gui/dialogs/TexturePackFilterDialog.java
+++ b/src/main/java/net/ftb/gui/dialogs/TexturePackFilterDialog.java
@@ -54,7 +54,7 @@ public class TexturePackFilterDialog extends JDialog {
 
         int textures = TexturePack.getTexturePackArray().size();
 
-        ArrayList<String> res = Lists.newArrayList();
+        List<String> res = Lists.newArrayList();
         res.add(I18N.getLocaleString("MAIN_ALL"));
         for (int i = 0; i < textures; i++) {
             if (!res.contains(TexturePack.getTexturePack(i).getResolution())) {
@@ -62,8 +62,8 @@ public class TexturePackFilterDialog extends JDialog {
             }
         }
 
-        ArrayList<String> comp = Lists.newArrayList();
-        final ArrayList<String> compNoVersion = Lists.newArrayList();
+        List<String> comp = Lists.newArrayList();
+        final List<String> compNoVersion = Lists.newArrayList();
         comp.add(I18N.getLocaleString("MAIN_ALL"));
         compNoVersion.add(I18N.getLocaleString("MAIN_ALL"));
 

--- a/src/main/java/net/ftb/gui/panes/AbstractModPackPane.java
+++ b/src/main/java/net/ftb/gui/panes/AbstractModPackPane.java
@@ -46,6 +46,8 @@ import java.awt.event.MouseEvent;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javax.swing.*;
 
@@ -55,7 +57,7 @@ public abstract class AbstractModPackPane extends JPanel {
     // container for packs. Upgraded by appPack()
     JPanel packs;
     // array to store packs. Upgraded by addPack
-    public ArrayList<JPanel> packPanels;
+    public List<JPanel> packPanels;
 
 
     JLabel typeLbl;
@@ -67,7 +69,7 @@ public abstract class AbstractModPackPane extends JPanel {
     JComboBox version;
 
     boolean modPacksAdded = false;
-    HashMap<ModPack, JPanel> panelByPack = Maps.newHashMap();
+    Map<ModPack, JPanel> panelByPack = Maps.newHashMap();
     @Setter
     @Getter
     ModPack selectedPack;

--- a/src/main/java/net/ftb/gui/panes/MapUtils.java
+++ b/src/main/java/net/ftb/gui/panes/MapUtils.java
@@ -46,7 +46,7 @@ import javax.swing.*;
 public class MapUtils extends JPanel implements ILauncherPane, MapListener {
 
     protected static JPanel maps;
-    public static ArrayList<JPanel> mapPanels;
+    public static List<JPanel> mapPanels;
 
     @Getter
     private static JScrollPane mapsScroll;
@@ -71,7 +71,7 @@ public class MapUtils extends JPanel implements ILauncherPane, MapListener {
     @Getter
     private static MapUtils instance;
 
-    private static HashMap<Integer, Map> currentMaps = Maps.newHashMap();
+    private static java.util.Map<Integer, Map> currentMaps = Maps.newHashMap();
 
     public MapUtils () {
         super();
@@ -264,7 +264,7 @@ public class MapUtils extends JPanel implements ILauncherPane, MapListener {
         mapInfo.setText("");
         ModPack FTBPack = FTBPacksPane.getInstance().getSelectedPack();
         ModPack ThirdpartyPack = ThirdPartyPane.getInstance().getSelectedPack();
-        HashMap<Integer, List<Map>> sorted = Maps.newHashMap();
+        java.util.Map<Integer, List<Map>> sorted = Maps.newHashMap();
         sorted.put(0, new ArrayList<Map>());
         sorted.put(1, new ArrayList<Map>());
         for (Map map : Map.getMapArray()) {

--- a/src/main/java/net/ftb/gui/panes/TexturepackPane.java
+++ b/src/main/java/net/ftb/gui/panes/TexturepackPane.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.swing.*;
 
@@ -48,7 +49,7 @@ public class TexturepackPane extends JPanel implements ILauncherPane, TexturePac
 
     private static JPanel texturePacks;
 
-    public static ArrayList<JPanel> texturePackPanels;
+    public static List<JPanel> texturePackPanels;
 
     @Getter
     private static JScrollPane texturePacksScroll;
@@ -69,7 +70,7 @@ public class TexturepackPane extends JPanel implements ILauncherPane, TexturePac
     @Getter
     private static TexturepackPane instance;
 
-    private static HashMap<Integer, TexturePack> currentTexturePacks = Maps.newHashMap();
+    private static Map<Integer, TexturePack> currentTexturePacks = Maps.newHashMap();
 
     public static boolean loaded = false;
 
@@ -249,7 +250,7 @@ public class TexturepackPane extends JPanel implements ILauncherPane, TexturePac
         texturePacks.repaint();
         ModPack FTBPack = FTBPacksPane.getInstance().getSelectedPack();
         ModPack ThirdpartyPack = ThirdPartyPane.getInstance().getSelectedPack();
-        HashMap<Integer, List<TexturePack>> sorted = Maps.newHashMap();
+        Map<Integer, List<TexturePack>> sorted = Maps.newHashMap();
         sorted.put(0, new ArrayList<TexturePack>());
         sorted.put(1, new ArrayList<TexturePack>());
         for (TexturePack texturePack : TexturePack.getTexturePackArray()) {

--- a/src/main/java/net/ftb/locale/I18N.java
+++ b/src/main/java/net/ftb/locale/I18N.java
@@ -25,14 +25,15 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 public class I18N {
     private static Properties locales = new Properties();
     private static Properties fallback = new Properties();
     private static File dir = new File(OSUtils.getDynamicStorageLocation(), "locale");
-    public static HashMap<String, String> localeFiles = Maps.newHashMap();
-    public final static HashMap<Integer, String> localeIndices = Maps.newHashMap();
+    public static Map<String, String> localeFiles = Maps.newHashMap();
+    public final static Map<Integer, String> localeIndices = Maps.newHashMap();
     public static Locale currentLocale = Locale.enUS;
 
     public enum Locale {

--- a/src/main/java/net/ftb/tools/TextureManager.java
+++ b/src/main/java/net/ftb/tools/TextureManager.java
@@ -41,6 +41,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import javax.swing.*;
@@ -56,7 +57,7 @@ public class TextureManager extends JDialog {
     private final JLabel label;
     public static boolean updating = false;
     private static String sep = File.separator;
-    private static HashMap<String, String> installedTextures;
+    private static Map<String, String> installedTextures;
 
     private class TexturePackManagerWorker extends SwingWorker<Boolean, Void> {
         @Override

--- a/src/main/java/net/ftb/util/DownloadUtils.java
+++ b/src/main/java/net/ftb/util/DownloadUtils.java
@@ -49,6 +49,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Formatter;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Scanner;
@@ -591,7 +592,7 @@ public class DownloadUtils extends Thread {
      * @param location - location to test on the repo ex: edges.json would test ${repoURL}/edges.json
      */
     @NonNull
-    public void parseJSONtoMap (URL u, String name, HashMap<String, String> h, boolean testEntries, String location) {
+    public void parseJSONtoMap (URL u, String name, Map<String, String> h, boolean testEntries, String location) {
         try {
             String json = IOUtils.toString(u);
             JsonElement element = new JsonParser().parse(json);

--- a/src/main/java/net/ftb/workers/ModpackLoader.java
+++ b/src/main/java/net/ftb/workers/ModpackLoader.java
@@ -42,7 +42,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class ModpackLoader extends Thread {
-    private ArrayList<String> xmlFiles = Lists.newArrayList();
+    private List<String> xmlFiles = Lists.newArrayList();
     private boolean disableOtherLoader = false;
     private static int offset = 0;
 

--- a/src/main/java/net/ftb/workers/UnreadNewsWorker.java
+++ b/src/main/java/net/ftb/workers/UnreadNewsWorker.java
@@ -21,6 +21,7 @@ import net.ftb.util.Benchmark;
 import net.ftb.util.NewsUtils;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.*;
 
@@ -33,7 +34,7 @@ public class UnreadNewsWorker extends SwingWorker<Integer, Void> {
     protected Integer doInBackground () {
         Benchmark.start("UnreadNews");
         int i = 0;
-        ArrayList<String> dates = NewsUtils.getPubDates();
+        List<String> dates = NewsUtils.getPubDates();
         Long lastRead = Long.parseLong(Settings.getSettings().getNewsDate());
         int read = 0;
         for (String s : dates) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.