### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/net/feed_the_beast/launcher/json/versions/Library.java
+++ b/src/main/java/net/feed_the_beast/launcher/json/versions/Library.java
@@ -68,11 +68,11 @@ public class Library {
         if (_artifact == null) {
             _artifact = new Artifact(name);
         }
-        return _artifact.getPath(natives.get(OS.CURRENT).replace("${arch}", (Settings.getSettings().getCurrentJava().is64bits ? "64" : "32")));
+        return _artifact.getPath(natives.get(OS.CURRENT).replace("${arch}", Settings.getSettings().getCurrentJava().is64bits ? "64" : "32"));
     }
 
     public String getUrl () {
-        return (url == null ? (localRepo ? DownloadUtils.getCreeperhostLink(Locations.ftb_maven) : Locations.mc_libs) : url);
+        return (url == null ? localRepo ? DownloadUtils.getCreeperhostLink(Locations.ftb_maven) : Locations.mc_libs : url);
     }
 
     @Override

--- a/src/main/java/net/ftb/events/PackChangeEvent.java
+++ b/src/main/java/net/ftb/events/PackChangeEvent.java
@@ -63,7 +63,7 @@ public class PackChangeEvent implements ILauncherEvent {
         names = new String[packs.size()];
         int cnt = 0;
         for (ModPack pack : packs) {
-            names[cnt] = (pack.getName());
+            names[cnt] = pack.getName();
             cnt++;
         }
     }

--- a/src/main/java/net/ftb/gui/dialogs/EditModPackDialog.java
+++ b/src/main/java/net/ftb/gui/dialogs/EditModPackDialog.java
@@ -266,7 +266,7 @@ public class EditModPackDialog extends JDialog {
      * @return The name of the original file, including the original "disabled" state, or an absent optional if no match was made
      */
     private Optional<String> defaultFile (Set<String> defaultMods, String fileName) {
-        String alternate = (fileName.endsWith(".disabled") ? fileName.substring(0, fileName.length() - ".disabled".length()) : fileName + ".disabled");
+        String alternate = fileName.endsWith(".disabled") ? fileName.substring(0, fileName.length() - ".disabled".length()) : fileName + ".disabled";
 
         if (defaultMods.contains(fileName.toLowerCase())) {
             return Optional.of(fileName.toLowerCase());

--- a/src/main/java/net/ftb/gui/panes/AbstractModPackPane.java
+++ b/src/main/java/net/ftb/gui/panes/AbstractModPackPane.java
@@ -233,7 +233,7 @@ public abstract class AbstractModPackPane extends JPanel {
         @Override
         public void actionPerformed (ActionEvent arg0) {
             if (version.getItemCount() > 0) {
-                Settings.getSettings().setPackVer((String.valueOf(version.getSelectedItem()).equalsIgnoreCase("recommended") ? "Recommended Version" : String.valueOf(version.getSelectedItem())));
+                Settings.getSettings().setPackVer(String.valueOf(version.getSelectedItem()).equalsIgnoreCase("recommended") ? "Recommended Version" : String.valueOf(version.getSelectedItem()));
                 Settings.getSettings().save();
             }
         }
@@ -288,8 +288,8 @@ public abstract class AbstractModPackPane extends JPanel {
         packPanels.add(p);
         packs.add(p);
 
-        packs.setMinimumSize(new Dimension(420, (packPanels.size() * (55 + ObjectInfoSplitPane.verticalItemPadding))));
-        packs.setPreferredSize(new Dimension(420, (packPanels.size() * (55 + ObjectInfoSplitPane.verticalItemPadding))));
+        packs.setMinimumSize(new Dimension(420, packPanels.size() * (55 + ObjectInfoSplitPane.verticalItemPadding)));
+        packs.setPreferredSize(new Dimension(420, packPanels.size() * (55 + ObjectInfoSplitPane.verticalItemPadding)));
 
         //packsScroll.revalidate();
         if (pack.getDir().equalsIgnoreCase(getLastPack())) {
@@ -427,7 +427,7 @@ public abstract class AbstractModPackPane extends JPanel {
 
     boolean textSearch (ModPack pack) {
         String s  = searchString.toLowerCase();
-        return ((s.isEmpty()) || pack.getName().toLowerCase().contains(s) || pack.getAuthor().toLowerCase().contains(s));
+        return (s.isEmpty() || pack.getName().toLowerCase().contains(s) || pack.getAuthor().toLowerCase().contains(s));
     }
 
     abstract boolean filterForTab (ModPack pack);

--- a/src/main/java/net/ftb/gui/panes/FTBPacksPane.java
+++ b/src/main/java/net/ftb/gui/panes/FTBPacksPane.java
@@ -41,7 +41,7 @@ public class FTBPacksPane extends AbstractModPackPane implements ILauncherPane {
     }
 
     boolean filterForTab (ModPack pack) {
-        return (!pack.isThirdPartyTab());
+        return !pack.isThirdPartyTab();
     }
 
     String getLastPack () {

--- a/src/main/java/net/ftb/gui/panes/MapUtils.java
+++ b/src/main/java/net/ftb/gui/panes/MapUtils.java
@@ -236,8 +236,8 @@ public class MapUtils extends JPanel implements ILauncherPane, MapListener {
         mapPanels.add(p);
         maps.add(p);
 
-        maps.setMinimumSize(new Dimension(420, (mapPanels.size() * (55 + ObjectInfoSplitPane.verticalItemPadding))));
-        maps.setPreferredSize(new Dimension(420, (mapPanels.size() * (55 + ObjectInfoSplitPane.verticalItemPadding))));
+        maps.setMinimumSize(new Dimension(420, mapPanels.size() * (55 + ObjectInfoSplitPane.verticalItemPadding)));
+        maps.setPreferredSize(new Dimension(420, mapPanels.size() * (55 + ObjectInfoSplitPane.verticalItemPadding)));
 
     }
 
@@ -346,7 +346,7 @@ public class MapUtils extends JPanel implements ILauncherPane, MapListener {
     private static int getMapNum () {
         if (currentMaps.size() > 0) {
             if (!origin.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL"))) {
-                return currentMaps.get((mapPanels.size() - 1)).getIndex();
+                return currentMaps.get(mapPanels.size() - 1).getIndex();
             }
         }
         return mapPanels.size();
@@ -362,11 +362,11 @@ public class MapUtils extends JPanel implements ILauncherPane, MapListener {
     }
 
     private static boolean compatibilityCheck (Map map) {
-        return (compatible.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || map.isCompatible(compatible));
+        return compatible.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || map.isCompatible(compatible);
     }
 
     private static boolean textSearch (Map map) {
         String searchString = SearchDialog.lastMapSearch.toLowerCase();
-        return ((searchString.isEmpty()) || map.getName().toLowerCase().contains(searchString) || map.getAuthor().toLowerCase().contains(searchString));
+        return (searchString.isEmpty() || map.getName().toLowerCase().contains(searchString) || map.getAuthor().toLowerCase().contains(searchString));
     }
 }

--- a/src/main/java/net/ftb/gui/panes/TexturepackPane.java
+++ b/src/main/java/net/ftb/gui/panes/TexturepackPane.java
@@ -223,8 +223,8 @@ public class TexturepackPane extends JPanel implements ILauncherPane, TexturePac
         texturePackPanels.add(p);
         texturePacks.add(p);
 
-        texturePacks.setMinimumSize(new Dimension(420, (texturePackPanels.size() * (55 + ObjectInfoSplitPane.verticalItemPadding))));
-        texturePacks.setPreferredSize(new Dimension(420, (texturePackPanels.size() * (55 + ObjectInfoSplitPane.verticalItemPadding))));
+        texturePacks.setMinimumSize(new Dimension(420, texturePackPanels.size() * (55 + ObjectInfoSplitPane.verticalItemPadding)));
+        texturePacks.setPreferredSize(new Dimension(420, texturePackPanels.size() * (55 + ObjectInfoSplitPane.verticalItemPadding)));
 
     }
 
@@ -328,7 +328,7 @@ public class TexturepackPane extends JPanel implements ILauncherPane, TexturePac
     private static int getTexturePackNum () {
         if (currentTexturePacks.size() > 0) {
             if (!compatible.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || !resolution.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL"))) {
-                return currentTexturePacks.get((texturePackPanels.size() - 1)).getIndex();
+                return currentTexturePacks.get(texturePackPanels.size() - 1).getIndex();
             }
         }
         return texturePackPanels.size();
@@ -339,16 +339,16 @@ public class TexturepackPane extends JPanel implements ILauncherPane, TexturePac
     }
 
     private static boolean compatibilityCheck (TexturePack tp) {
-        return (compatible.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || tp.isCompatible(compatible));
+        return compatible.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || tp.isCompatible(compatible);
     }
 
     private static boolean resolutionCheck (TexturePack tp) {
-        return (resolution.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || tp.getResolution().equalsIgnoreCase(resolution));
+        return resolution.equalsIgnoreCase(I18N.getLocaleString("MAIN_ALL")) || tp.getResolution().equalsIgnoreCase(resolution);
     }
 
     private static boolean textSearch (TexturePack tp) {
         String searchString = SearchDialog.lastTextureSearch.toLowerCase();
-        return ((searchString.isEmpty()) || tp.getName().toLowerCase().contains(searchString) || tp.getAuthor().toLowerCase().contains(searchString));
+        return (searchString.isEmpty() || tp.getName().toLowerCase().contains(searchString) || tp.getAuthor().toLowerCase().contains(searchString));
     }
 
 }

--- a/src/main/java/net/ftb/gui/panes/ThirdPartyPane.java
+++ b/src/main/java/net/ftb/gui/panes/ThirdPartyPane.java
@@ -40,7 +40,7 @@ public class ThirdPartyPane extends AbstractModPackPane implements ILauncherPane
     }
 
     boolean filterForTab (ModPack pack) {
-        return (pack.isThirdPartyTab() && !pack.getParentXml().contains(Locations.MODPACKXML));
+        return pack.isThirdPartyTab() && !pack.getParentXml().contains(Locations.MODPACKXML);
     }
 
     String getLastPack () {

--- a/src/main/java/net/ftb/main/Main.java
+++ b/src/main/java/net/ftb/main/Main.java
@@ -445,9 +445,9 @@ public class Main {
         int v = CommandLineSettings.getSettings().getManualVersion();
         int b = CommandLineSettings.getSettings().getManualBuildNumber();
         UpdateChecker updateChecker = new UpdateChecker(
-                (v == 0  ? Constants.buildNumber : v),
+                v == 0  ? Constants.buildNumber : v,
                 LaunchFrame.getInstance().minUsable,
-                (b == 0 ? beta_ : b)
+                b == 0 ? beta_ : b
         ) {
             @Override
             protected void done () {

--- a/src/main/java/net/ftb/minecraft/MCInstaller.java
+++ b/src/main/java/net/ftb/minecraft/MCInstaller.java
@@ -293,7 +293,7 @@ public class MCInstaller {
                                     local.delete();
                                 }
                                 if (!local.exists()) {
-                                    return (new DownloadInfo(new URL(Locations.mc_res + path), local, name, Lists.newArrayList(asset.hash), "sha1"));
+                                    return new DownloadInfo(new URL(Locations.mc_res + path), local, name, Lists.newArrayList(asset.hash), "sha1");
                                 }
                             } catch (Exception ex) {
                                 Logger.logError("Asset hash check failed", ex);
@@ -526,7 +526,7 @@ public class MCInstaller {
         if (count == 2) {
             // forge > 1291 has three subsection, third section is name of the branch
             // e.g. 1.7.10-10.13.2.1352-1.7.10 or
-            fgRelease = fgVsn.substring((StringUtils.indexOf(fgVsn, "-") + 1), (StringUtils.lastIndexOf(fgVsn, "-")));
+            fgRelease = fgVsn.substring(StringUtils.indexOf(fgVsn, "-") + 1, StringUtils.lastIndexOf(fgVsn, "-"));
             fgRelease = fgRelease.substring(StringUtils.lastIndexOf(fgRelease, ".") + 1);
             vsn_ = Integer.parseInt(fgRelease);
         } else if (count == 1 || count == 0) {

--- a/src/main/java/net/ftb/minecraft/MCLauncher.java
+++ b/src/main/java/net/ftb/minecraft/MCLauncher.java
@@ -341,23 +341,23 @@ public class MCLauncher {
 
     public static String parseLegacyArgs (String s) {
         if (s.equals("${animation_name}")) {
-            return (((!ModPack.getSelectedPack().getAnimation().equalsIgnoreCase("empty")) ? OSUtils.getCacheStorageLocation() + "ModPacks" + separator + ModPack.getSelectedPack().getDir()
-                    + separator + ModPack.getSelectedPack().getAnimation() : "empty"));
+            return !ModPack.getSelectedPack().getAnimation().equalsIgnoreCase("empty") ? OSUtils.getCacheStorageLocation() + "ModPacks" + separator + ModPack.getSelectedPack().getDir()
+                    + separator + ModPack.getSelectedPack().getAnimation() : "empty";
         } else if (s.equals("${forge_name}")) {
             return Locations.FORGENAME;
         } else if (s.equals("${pack_name}")) {
-            return (ModPack.getSelectedPack().getName() + " v"
-                            + (Settings.getSettings().getPackVer().equalsIgnoreCase("recommended version") ? ModPack.getSelectedPack().getVersion() : Settings.getSettings().getPackVer()));
+            return ModPack.getSelectedPack().getName() + " v"
+                            + (Settings.getSettings().getPackVer().equalsIgnoreCase("recommended version") ? ModPack.getSelectedPack().getVersion() : Settings.getSettings().getPackVer());
         } else if (s.equals("${pack_image}")) {
-            return (OSUtils.getCacheStorageLocation() + "ModPacks" + separator + ModPack.getSelectedPack().getDir() + separator + ModPack.getSelectedPack().getLogoName());
+            return OSUtils.getCacheStorageLocation() + "ModPacks" + separator + ModPack.getSelectedPack().getDir() + separator + ModPack.getSelectedPack().getLogoName();
         } else if (s.equals("${extended_state}")) {
-            return (String.valueOf(Settings.getSettings().getLastExtendedState()));
+            return String.valueOf(Settings.getSettings().getLastExtendedState());
         } else if (s.equals("${width}")) {
-            return (String.valueOf(Settings.getSettings().getLastDimension().getWidth()));
+            return String.valueOf(Settings.getSettings().getLastDimension().getWidth());
         } else if (s.equals("${height}")) {
-            return (String.valueOf(Settings.getSettings().getLastDimension().getHeight()));
+            return String.valueOf(Settings.getSettings().getLastDimension().getHeight());
         } else if (s.equals("${minecraft_jar}")) {
-            return (gameDirectory + File.separator + "bin" + File.separator + Locations.OLDMCJARNAME);
+            return gameDirectory + File.separator + "bin" + File.separator + Locations.OLDMCJARNAME;
         } else {
             return s;
         }
@@ -382,7 +382,7 @@ public class MCLauncher {
             String[] files = libsDir.list();
             Arrays.sort(files);
             for (String name : files) {
-                if ((name.toLowerCase().endsWith(".zip") || name.toLowerCase().endsWith(".jar"))) {
+                if (name.toLowerCase().endsWith(".zip") || name.toLowerCase().endsWith(".jar")) {
                     cpb.append(OSUtils.getJavaDelimiter());
                     cpb.append(new File(libsDir, name).getAbsolutePath());
                 }

--- a/src/main/java/net/ftb/tools/ModManager.java
+++ b/src/main/java/net/ftb/tools/ModManager.java
@@ -210,7 +210,7 @@ public class ModManager extends JDialog {
             String installPath = Settings.getSettings().getInstallPath();
             ModPack pack = ModPack.getSelectedPack();
             //clearModsFolder(pack);
-            String baseLink = (pack.isPrivatePack() ? PRIVATEPACKS + dir + "/" + curVersion + "/" : MODPACKS + dir + "/" + curVersion + "/");
+            String baseLink = pack.isPrivatePack() ? PRIVATEPACKS + dir + "/" + curVersion + "/" : MODPACKS + dir + "/" + curVersion + "/";
             baseDynamic = new File(dynamicLoc, "ModPacks" + sep + dir + sep);
 
             Logger.logDebug("pack dir: " + dir);

--- a/src/main/java/net/ftb/tracking/google/GoogleAnalytics.java
+++ b/src/main/java/net/ftb/tracking/google/GoogleAnalytics.java
@@ -124,13 +124,13 @@ public class GoogleAnalytics {
 
         sb.append("&utmcc=__utma%3D").append(hostnameHash).append(".").append(visitorId).append(".").append(timestampFirst).append(".").append(timestampPrevious).append(".").append(timestampCurrent)
                 .append(".").append(visits).append("%3B%2B__utmz%3D").append(hostnameHash).append(".").append(timestampCurrent).append(".1.1.utmcsr%3D").append(utmcsr).append("%7Cutmccn%3D")
-                .append(utmccn).append("%7Cutmcmd%3D").append(utmcmd).append((utmctr != null ? "%7Cutmctr%3D" + utmctr : "")).append((utmcct != null ? "%7Cutmcct%3D" + utmcct : ""))
+                .append(utmccn).append("%7Cutmcmd%3D").append(utmcmd).append(utmctr != null ? "%7Cutmctr%3D" + utmctr : "").append(utmcct != null ? "%7Cutmcct%3D" + utmcct : "")
                 .append("%3B&gaq=1");
         return sb.toString();
     }
 
     private String getURIString (String argString) {
-        return (argString == null ? null : URIEncoder.encodeURI(argString));
+        return argString == null ? null : URIEncoder.encodeURI(argString);
     }
 
     private int hostnameHash (String hostname) {

--- a/src/main/java/net/ftb/tracking/google/JGoogleAnalyticsTracker.java
+++ b/src/main/java/net/ftb/tracking/google/JGoogleAnalyticsTracker.java
@@ -256,7 +256,7 @@ public class JGoogleAnalyticsTracker {
                 fifoEmpty = (fifo.size() == 0);
             }
             synchronized (JGoogleAnalyticsTracker.class) {
-                asyncThreadsCompleted = (asyncThreadsRunning == 0);
+                asyncThreadsCompleted = asyncThreadsRunning == 0;
             }
             if (fifoEmpty && asyncThreadsCompleted) {
                 break;

--- a/src/main/java/net/ftb/tracking/google/VisitorData.java
+++ b/src/main/java/net/ftb/tracking/google/VisitorData.java
@@ -68,7 +68,7 @@ public class VisitorData {
      * initializes a new visitor data, with new visitorid
      */
     public static VisitorData newVisitor () {
-        int visitorId = (new SecureRandom().nextInt() & 0x7FFFFFFF);
+        int visitorId = new SecureRandom().nextInt() & 0x7FFFFFFF;
         long now = now();
         return new VisitorData(visitorId, now, now, now, 1);
     }

--- a/src/main/java/net/ftb/util/Benchmark.java
+++ b/src/main/java/net/ftb/util/Benchmark.java
@@ -47,7 +47,7 @@ public class Benchmark {
      * @return how many ms since timer was started
      */
     private static Long bench (String name) {
-        return (System.currentTimeMillis() - startTimes.get(name));
+        return System.currentTimeMillis() - startTimes.get(name);
     }
 
     /**

--- a/src/main/java/net/ftb/util/ComparableVersion.java
+++ b/src/main/java/net/ftb/util/ComparableVersion.java
@@ -182,7 +182,7 @@ public class ComparableVersion
         }
 
         public boolean isNull () {
-            return (comparableQualifier(value).compareTo(RELEASE_VERSION_INDEX) == 0);
+            return comparableQualifier(value).compareTo(RELEASE_VERSION_INDEX) == 0;
         }
 
         /**
@@ -241,7 +241,7 @@ public class ComparableVersion
         }
 
         public boolean isNull () {
-            return (size() == 0);
+            return size() == 0;
         }
 
         void normalize () {

--- a/src/main/java/net/ftb/util/DownloadUtils.java
+++ b/src/main/java/net/ftb/util/DownloadUtils.java
@@ -62,7 +62,7 @@ public class DownloadUtils extends Thread {
      * @return - the direct link
      */
     public static String getCreeperhostLink (String file) {
-        String resolved = (downloadServers.containsKey(Settings.getSettings().getDownloadServer())) ? "http://" + downloadServers.get(Settings.getSettings().getDownloadServer())
+        String resolved = downloadServers.containsKey(Settings.getSettings().getDownloadServer()) ? "http://" + downloadServers.get(Settings.getSettings().getDownloadServer())
                 : Locations.masterRepo;
         resolved += "/FTB2/" + file;
         HttpURLConnection connection = null;
@@ -95,7 +95,7 @@ public class DownloadUtils extends Thread {
      * @return - the direct static link or the backup link if the file isn't found
      */
     public static String getStaticCreeperhostLinkOrBackup (String file, String backupLink) {
-        String resolved = (downloadServers.containsKey(Settings.getSettings().getDownloadServer())) ? "http://" + downloadServers.get(Settings.getSettings().getDownloadServer())
+        String resolved = downloadServers.containsKey(Settings.getSettings().getDownloadServer()) ? "http://" + downloadServers.get(Settings.getSettings().getDownloadServer())
                 : Locations.masterRepo;
         resolved += "/FTB2/static/" + file;
         HttpURLConnection connection = null;
@@ -139,7 +139,7 @@ public class DownloadUtils extends Thread {
      * @return - the direct link
      */
     public static String getStaticCreeperhostLink (String file) {
-        String resolved = (downloadServers.containsKey(Settings.getSettings().getDownloadServer())) ? "http://" + downloadServers.get(Settings.getSettings().getDownloadServer())
+        String resolved = downloadServers.containsKey(Settings.getSettings().getDownloadServer()) ? "http://" + downloadServers.get(Settings.getSettings().getDownloadServer())
                 : Locations.masterRepo;
         resolved += "/FTB2/static/" + file;
         HttpURLConnection connection = null;
@@ -176,7 +176,7 @@ public class DownloadUtils extends Thread {
             HttpURLConnection connection = (HttpURLConnection) new URL(getStaticCreeperhostLink(file)).openConnection();
             connection.setRequestProperty(CACHE_CONTROL, "no-transform");
             connection.setRequestMethod("HEAD");
-            return (connection.getResponseCode() == 200);
+            return connection.getResponseCode() == 200;
         } catch (Exception e) {
             return false;
         }
@@ -191,7 +191,7 @@ public class DownloadUtils extends Thread {
             HttpURLConnection connection = (HttpURLConnection) new URL(Locations.masterRepo + "/FTB2/" + file).openConnection();
             connection.setRequestProperty(CACHE_CONTROL, "no-transform");
             connection.setRequestMethod("HEAD");
-            return (connection.getResponseCode() == 200);
+            return connection.getResponseCode() == 200;
         } catch (Exception e) {
             return false;
         }
@@ -207,7 +207,7 @@ public class DownloadUtils extends Thread {
             connection.setRequestProperty(CACHE_CONTROL, "no-transform");
             connection.setRequestMethod("HEAD");
             int code = connection.getResponseCode();
-            return (code == 200);
+            return code == 200;
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/net/ftb/util/ModPackUtil.java
+++ b/src/main/java/net/ftb/util/ModPackUtil.java
@@ -86,7 +86,7 @@ public final class ModPackUtil {
     private static String getModpackCacheKey (@Nonnull ModPack modpack) {
         //Using the directory combined with the URL, because this is used as the cached download location for each mod,
         //and should therefore be guaranteed unique per modpack
-        return (modpack.getDir() + ":" + modpack.getUrl());
+        return modpack.getDir() + ":" + modpack.getUrl();
     }
 
     /**

--- a/src/main/java/net/ftb/util/OSUtils.java
+++ b/src/main/java/net/ftb/util/OSUtils.java
@@ -293,7 +293,7 @@ public class OSUtils {
     public static boolean is64BitWindows () {
         String arch = System.getenv("PROCESSOR_ARCHITECTURE");
         String wow64Arch = System.getenv("PROCESSOR_ARCHITEW6432");
-        return (arch.endsWith("64") || (wow64Arch != null && wow64Arch.endsWith("64")));
+        return (arch.endsWith("64") || wow64Arch != null && wow64Arch.endsWith("64"));
     }
 
     /**

--- a/src/main/java/net/ftb/util/winreg/JavaInfo.java
+++ b/src/main/java/net/ftb/util/winreg/JavaInfo.java
@@ -76,7 +76,7 @@ public class JavaInfo extends JavaVersion {
      * @return
      */
     public boolean isIdentical (JavaInfo j) {
-        return (this.isSameVersion(j) && sameBitness(j));
+        return this.isSameVersion(j) && sameBitness(j);
     }
 
     /**

--- a/src/main/java/net/ftb/util/winreg/WinRegistry.java
+++ b/src/main/java/net/ftb/util/winreg/WinRegistry.java
@@ -122,7 +122,7 @@ public class WinRegistry {
         }
         byte[] valb = (byte[]) regQueryValueEx.invoke(root, handles[0], toCstr(value));
         regCloseKey.invoke(root, handles[0]);
-        return (valb != null ? new String(valb).trim() : null);
+        return valb != null ? new String(valb).trim() : null;
     }
 
     //========================================================================

--- a/src/main/java/net/ftb/workers/AuthlibHelper.java
+++ b/src/main/java/net/ftb/workers/AuthlibHelper.java
@@ -151,7 +151,7 @@ public class AuthlibHelper {
             if (isValid(authentication)) {
                 Logger.logDebug("Authentication is valid ");
                 displayName = authentication.getSelectedProfile().getName();
-                if ((authentication.isLoggedIn()) && (authentication.canPlayOnline())) {
+                if (authentication.isLoggedIn() && (authentication.canPlayOnline())) {
                     Logger.logDebug("loggedIn() && CanPlayOnline()");
                     if ((authentication instanceof YggdrasilUserAuthentication)) {
                         UserManager.setStore(user, encode(authentication.saveForStorage()));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.