### PR TITLE
 "static" members should be accessed statically

### DIFF
--- a/src/main/java/net/ftb/gui/LaunchFrame.java
+++ b/src/main/java/net/ftb/gui/LaunchFrame.java
@@ -916,7 +916,7 @@ public class LaunchFrame extends JFrame {
         ModPack pack = ModPack.getSelectedPack();
 
         // save ´pack being launched
-        if (instance.currentPane == Panes.MODPACK) {
+        if (LaunchFrame.currentPane == Panes.MODPACK) {
             Settings.getSettings().setLastFTBPack(FTBPacksPane.getInstance().getSelectedPack().getDir());
         } else {
             Settings.getSettings().setLastThirdPartyPack(ThirdPartyPane.getInstance().getSelectedPack().getDir());

--- a/src/main/java/net/ftb/workers/AuthlibDLWorker.java
+++ b/src/main/java/net/ftb/workers/AuthlibDLWorker.java
@@ -74,10 +74,10 @@ public class AuthlibDLWorker extends SwingWorker<Boolean, Void> {
         try {
             if (f.exists()) {
                 addURL(f.toURI().toURL());
-                this.getClass().forName("com.mojang.authlib.exceptions.AuthenticationException"); //will fail if not properly added to classpath
-                this.getClass().forName("com.mojang.authlib.Agent");
-                this.getClass().forName("com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService");
-                this.getClass().forName("com.mojang.authlib.yggdrasil.YggdrasilUserAuthentication");
+                AuthlibDLWorker.class.forName("com.mojang.authlib.exceptions.AuthenticationException"); //will fail if not properly added to classpath
+                AuthlibDLWorker.class.forName("com.mojang.authlib.Agent");
+                AuthlibDLWorker.class.forName("com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService");
+                AuthlibDLWorker.class.forName("com.mojang.authlib.yggdrasil.YggdrasilUserAuthentication");
             } else {
                 Logger.logError("Authlib file does not exist");
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2209 - “ "static" members should be accessed statically”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2209
Please let me know if you have any questions.
Ayman Abdelghany.