### PR TITLE
Removing unused local variables

### DIFF
--- a/src/main/java/net/ftb/download/workers/AssetDownloader.java
+++ b/src/main/java/net/ftb/download/workers/AssetDownloader.java
@@ -81,7 +81,6 @@ public class AssetDownloader extends SwingWorker<Boolean, Void> {
         byte[] buffer = new byte[24000];
         boolean downloadSuccess = false;
         List<String> remoteHash = asset.hash;
-        String hashType;
         int attempt = 0;
         final int attempts = 5;
 

--- a/src/main/java/net/ftb/gui/dialogs/AdvancedOptionsDialog.java
+++ b/src/main/java/net/ftb/gui/dialogs/AdvancedOptionsDialog.java
@@ -170,7 +170,6 @@ public class AdvancedOptionsDialog extends JDialog {
         setTitle(I18N.getLocaleString("ADVANCED_OPTIONS_TITLE"));
         setResizable(true); // false
 
-        Container panel = getContentPane();
         getContentPane().setLayout(new MigLayout());
 
         downloadLocationLbl = new JLabel(I18N.getLocaleString("ADVANCED_OPTIONS_DLLOCATION"));

--- a/src/main/java/net/ftb/gui/panes/AbstractModPackPane.java
+++ b/src/main/java/net/ftb/gui/panes/AbstractModPackPane.java
@@ -248,7 +248,6 @@ public abstract class AbstractModPackPane extends JPanel {
             packs.removeAll();
             packs.repaint();
         }
-        final int packIndex = packPanels.size();
         final JPanel p = new JPanel();
         p.setPreferredSize(new Dimension(420, 55));
         p.setLayout(null);

--- a/src/main/java/net/ftb/tracking/google/GoogleAnalytics.java
+++ b/src/main/java/net/ftb/tracking/google/GoogleAnalytics.java
@@ -56,7 +56,6 @@ public class GoogleAnalytics {
         StringBuilder sb = new StringBuilder();
         sb.append(URL_PREFIX);
 
-        long now = System.currentTimeMillis();
 
         sb.append("?utmwv=").append(getGoogleAnalyticsVersion()); // version
         sb.append("&utmn=").append(random.nextInt()); // random int so no caching

--- a/src/main/java/net/ftb/util/DownloadUtils.java
+++ b/src/main/java/net/ftb/util/DownloadUtils.java
@@ -440,7 +440,6 @@ public class DownloadUtils extends Thread {
     public void run () {
         boolean bothReposFailed = false;
         boolean curseFailed = false;
-        boolean creeperFailed = false;
         setName("DownloadUtils");
         // test for proxies
         OSUtils.getProxy(Locations.curseRepo);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1481 - “Unused local variables should be removed ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1481
Please let me know if you have any questions.
Ayman Abdelghany.