### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/src/main/java/net/ftb/gui/panes/AbstractModPackPane.java
+++ b/src/main/java/net/ftb/gui/panes/AbstractModPackPane.java
@@ -128,7 +128,7 @@ public abstract class AbstractModPackPane extends JPanel {
         editModPack.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed (ActionEvent e) {
-                if (packPanels.size() > 0) {
+                if (!packPanels.isEmpty()) {
                     //TODO: fix by rename
                     EditModPackDialog empd = new EditModPackDialog(LaunchFrame.getInstance(), selectedPack);
                     empd.setVisible(true);
@@ -172,7 +172,7 @@ public abstract class AbstractModPackPane extends JPanel {
                 ModPack pack = selectedPack;
 
                 if ((LaunchFrame.currentPane == LaunchFrame.Panes.MODPACK || LaunchFrame.currentPane == LaunchFrame.Panes.THIRDPARTY) && !pack.getServerUrl().isEmpty()) {
-                    if (packPanels.size() > 0 ) {
+                    if (!packPanels.isEmpty()) {
                         if (!pack.getServerUrl().equals("") && pack.getServerUrl() != null) {
                             String version = (Settings.getSettings().getPackVer().equalsIgnoreCase("recommended version") || Settings.getSettings().getPackVer().equalsIgnoreCase("newest version"))
                                     ? pack.getVersion().replace(".", "_")

--- a/src/main/java/net/ftb/minecraft/MCInstaller.java
+++ b/src/main/java/net/ftb/minecraft/MCInstaller.java
@@ -63,7 +63,7 @@ public class MCInstaller {
         packmcversion = pack.getMcVersion(Settings.getSettings().getPackVer(pack.getDir()));
         packbasejson = "";
         List<DownloadInfo> assets = gatherAssets(new File(installPath), installPath, isLegacy);
-        if (assets != null && assets.size() > 0) {
+        if (assets != null && !assets.isEmpty()) {
             Logger.logInfo("Checking/Downloading " + assets.size() + " assets, this may take a while...");
 
             final ProgressMonitor prog = new ProgressMonitor(LaunchFrame.getInstance(), "Downloading Files...", "", 0, 100);

--- a/src/main/java/net/ftb/tracking/google/JGoogleAnalyticsTracker.java
+++ b/src/main/java/net/ftb/tracking/google/JGoogleAnalyticsTracker.java
@@ -253,7 +253,7 @@ public class JGoogleAnalyticsTracker {
         long absTimeout = System.currentTimeMillis() + timeoutMillis;
         while (System.currentTimeMillis() < absTimeout) {
             synchronized (fifo) {
-                fifoEmpty = (fifo.size() == 0);
+                fifoEmpty = (fifo.isEmpty());
             }
             synchronized (JGoogleAnalyticsTracker.class) {
                 asyncThreadsCompleted = (asyncThreadsRunning == 0);

--- a/src/main/java/net/ftb/util/winreg/JavaFinder.java
+++ b/src/main/java/net/ftb/util/winreg/JavaFinder.java
@@ -187,14 +187,14 @@ public class JavaFinder {
 
             }
 
-            if (java64.size() > 0) {
+            if (!java64.isEmpty()) {
                 for (JavaInfo aJava64 : java64) {
                     if (!preferred.is64bits || preferred.isOlder(aJava64)) {
                         preferred = aJava64;
                     }
                 }
             }
-            if (java32.size() > 0) {
+            if (!java32.isEmpty()) {
                 for (JavaInfo aJava32 : java32) {
                     if (!preferred.is64bits && preferred.isOlder(aJava32)) {
                         preferred = aJava32;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.