### PR TITLE
 Resources should be closed

### DIFF
--- a/src/main/java/net/ftb/util/OSUtils.java
+++ b/src/main/java/net/ftb/util/OSUtils.java
@@ -452,12 +452,21 @@ public class OSUtils {
     private static byte[] genHardwareIDUNIX () {
         String line;
         if (CommandLineSettings.getSettings().isUseMac()) {
+            BufferedReader reader = null;
             try {
-                BufferedReader reader = new BufferedReader(new FileReader("/etc/machine-id"));
+                reader = new BufferedReader(new FileReader("/etc/machine-id"));
                 line = reader.readLine();
             } catch (Exception e) {
                 Logger.logDebug("failed", e);
                 return new byte[] { };
+            } finally {
+                if(reader != null)
+                    try {
+                        reader.close();
+                    } catch (IOException e) {
+                        Logger.logWarn("Error while generating Hardware ID UNIX", e);
+                    }
+
             }
             return line.getBytes();
         } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2095 - “Resources should be closed”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Ayman Abdelghany.