### PR TITLE
Null pointers should not be dereferenced

### DIFF
--- a/src/main/java/net/ftb/util/FTBFileUtils.java
+++ b/src/main/java/net/ftb/util/FTBFileUtils.java
@@ -154,7 +154,8 @@ public class FTBFileUtils {
             backupSuccess = backupExtract(zipLocation, outputLocation);
         } finally {
             try {
-                zipinputstream.close();
+                if(zipinputstream != null)
+                    zipinputstream.close();
             } catch (IOException e) {
             }
         }
@@ -196,8 +197,10 @@ public class FTBFileUtils {
             success = false;
         } finally {
             try {
-                zis.closeEntry();
-                zis.close();
+                if(zis != null) {
+                    zis.closeEntry();
+                    zis.close();
+                }
             } catch (IOException e) {
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - “Null pointers should not be dereferenced”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259
Please let me know if you have any questions.
Ayman Abdelghany.