### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/net/feed_the_beast/launcher/json/JsonFactory.java
+++ b/src/main/java/net/feed_the_beast/launcher/json/JsonFactory.java
@@ -49,6 +49,9 @@ public class JsonFactory {
         GSON = builder.create();
     }
 
+    private JsonFactory() {
+    }
+
     public static RetiredPacks getRetiredPacks (File json) throws JsonSyntaxException, JsonIOException, IOException {
         FileReader reader = new FileReader(json);
         RetiredPacks packs = GSON.fromJson(reader, RetiredPacks.class);

--- a/src/main/java/net/ftb/data/Constants.java
+++ b/src/main/java/net/ftb/data/Constants.java
@@ -24,4 +24,6 @@ public class Constants {
     //limit for version component is 99.
     public static final int buildNumber = 1 * 100 * 100 + 4 * 100 + 12 * 1;
 
+    private Constants() {
+    }
 }

--- a/src/main/java/net/ftb/data/news/RSSReader.java
+++ b/src/main/java/net/ftb/data/news/RSSReader.java
@@ -37,6 +37,9 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 public class RSSReader {
 
+    private RSSReader() {
+    }
+
     public static List<NewsArticle> readRSS () {
         try {
             List<NewsArticle> news = Lists.newArrayList();

--- a/src/main/java/net/ftb/download/Locations.java
+++ b/src/main/java/net/ftb/download/Locations.java
@@ -95,4 +95,6 @@ public class Locations {
     public static final String launcherLogFile = "FTBLauncherLog.txt";
     public static final String minecraftLogFile = "MinecraftLog.txt";
 
+    private Locations() {
+    }
 }

--- a/src/main/java/net/ftb/gui/GuiConstants.java
+++ b/src/main/java/net/ftb/gui/GuiConstants.java
@@ -13,5 +13,8 @@ public class GuiConstants {
     public static final String FILL_SINGLE_LINE = "wrap, span, grow";
     public static final String SEP = ", ";
     public static final String GROW = "grow";
+
+    private GuiConstants() {
+    }
 }
 

--- a/src/main/java/net/ftb/locale/I18N.java
+++ b/src/main/java/net/ftb/locale/I18N.java
@@ -35,6 +35,9 @@ public class I18N {
     public final static HashMap<Integer, String> localeIndices = Maps.newHashMap();
     public static Locale currentLocale = Locale.enUS;
 
+    private I18N() {
+    }
+
     public enum Locale {
         cyGB, daDK, deDE, enGB, enUS, esES, fiFI, frCA, frFR, itIT, maHU, nlNL, noNO, plPL, ptBR, ptPT, ruRU, svSE, zhCN
     }

--- a/src/main/java/net/ftb/log/Logger.java
+++ b/src/main/java/net/ftb/log/Logger.java
@@ -36,6 +36,9 @@ public class Logger {
         logThread.start();
     }
 
+    private Logger() {
+    }
+
     public static void log (LogEntry entry) {
         logEntries.add(entry);
         logThread.handleLog(entry);

--- a/src/main/java/net/ftb/main/Main.java
+++ b/src/main/java/net/ftb/main/Main.java
@@ -92,6 +92,9 @@ public class Main {
     @Getter
     private static boolean disableLaunchButton = false;
 
+    private Main() {
+    }
+
     /**
      * Launch the application.
      * @param args - CLI arguments

--- a/src/main/java/net/ftb/main/MainHelpers.java
+++ b/src/main/java/net/ftb/main/MainHelpers.java
@@ -35,6 +35,9 @@ import java.io.OutputStreamWriter;
 import javax.swing.*;
 
 public class MainHelpers {
+    private MainHelpers() {
+    }
+
     public static void printInfo () {
         Logger.logInfo("FTBLaunch starting up (version " + Constants.version + " Build: " + Constants.buildNumber + ")");
         Logger.logDebug("System's default JVM: (This is not always used to launch MC)");

--- a/src/main/java/net/ftb/minecraft/MCInstaller.java
+++ b/src/main/java/net/ftb/minecraft/MCInstaller.java
@@ -59,6 +59,9 @@ public class MCInstaller {
     private static String packmcversion = new String();
     private static String packbasejson = new String();
 
+    private MCInstaller() {
+    }
+
     public static void setupNewStyle (final String installPath, final ModPack pack, final boolean isLegacy, final LoginResponse RESPONSE) {
         packmcversion = pack.getMcVersion(Settings.getSettings().getPackVer(pack.getDir()));
         packbasejson = "";

--- a/src/main/java/net/ftb/minecraft/MCLauncher.java
+++ b/src/main/java/net/ftb/minecraft/MCLauncher.java
@@ -61,6 +61,9 @@ public class MCLauncher {
     private static String gameDirectory;
     private static StringBuilder cpb;
 
+    private MCLauncher() {
+    }
+
     public static Process launchMinecraft (String javaPath, String gameFolder, File assetDir, File nativesDir, List<File> classpath, String mainClass, String args, String assetIndex, String rmax,
             String maxPermSize, String version, UserAuthentication authentication, boolean legacy) throws IOException {
 

--- a/src/main/java/net/ftb/tracking/google/URIEncoder.java
+++ b/src/main/java/net/ftb/tracking/google/URIEncoder.java
@@ -30,6 +30,9 @@ package net.ftb.tracking.google;
 public class URIEncoder {
     private static String mark = "-_.!~*'()\"";
 
+    private URIEncoder() {
+    }
+
     public static String encodeURI (String argString) {
         StringBuilder uri = new StringBuilder(); // Encoded URL
         char[] chars = argString.toCharArray();

--- a/src/main/java/net/ftb/tracking/google/system/AWTSystemPopulator.java
+++ b/src/main/java/net/ftb/tracking/google/system/AWTSystemPopulator.java
@@ -21,6 +21,9 @@ import net.ftb.tracking.google.AnalyticsConfigData;
 import java.awt.*;
 
 public class AWTSystemPopulator {
+    private AWTSystemPopulator() {
+    }
+
     public static final void populateConfigData (AnalyticsConfigData data) {
         data.setEncoding(System.getProperty("file.encoding"));
         String region = System.getProperty("user.region");

--- a/src/main/java/net/ftb/tracking/piwik/PiwikUtils.java
+++ b/src/main/java/net/ftb/tracking/piwik/PiwikUtils.java
@@ -7,6 +7,9 @@ import java.net.URLEncoder;
 
 public class PiwikUtils {
 
+    private PiwikUtils() {
+    }
+
     public static String urlEncode (String in) {
         String output;
         try {

--- a/src/main/java/net/ftb/updater/SelfUpdate.java
+++ b/src/main/java/net/ftb/updater/SelfUpdate.java
@@ -27,6 +27,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SelfUpdate {
+    private SelfUpdate() {
+    }
+
     public static void runUpdate (String currentPath, String temporaryUpdatePath) {
         List<String> arguments = Lists.newArrayList();
 

--- a/src/main/java/net/ftb/util/AppUtils.java
+++ b/src/main/java/net/ftb/util/AppUtils.java
@@ -37,6 +37,9 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 public class AppUtils {
+    private AppUtils() {
+    }
+
     /**
      * Reads all of the data from the given stream and returns it as a string.
      * @param stream the stream to read from.

--- a/src/main/java/net/ftb/util/Benchmark.java
+++ b/src/main/java/net/ftb/util/Benchmark.java
@@ -24,6 +24,9 @@ public class Benchmark {
     private static Long baseTime;
     private static ConcurrentHashMap<String, Long> startTimes = new ConcurrentHashMap<String, Long>();
 
+    private Benchmark() {
+    }
+
     /**
      * adds a new named timer for benchmarking
      */

--- a/src/main/java/net/ftb/util/CryptoUtils.java
+++ b/src/main/java/net/ftb/util/CryptoUtils.java
@@ -29,6 +29,9 @@ import javax.crypto.spec.SecretKeySpec;
 
 public class CryptoUtils {
 
+    private CryptoUtils() {
+    }
+
     /**
      * Newer implementation available if possible use {@link #decrypt(String str)}
      * @param str string to decrypt

--- a/src/main/java/net/ftb/util/ErrorUtils.java
+++ b/src/main/java/net/ftb/util/ErrorUtils.java
@@ -27,6 +27,9 @@ import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 
 public class ErrorUtils {
+    private ErrorUtils() {
+    }
+
     /**
      * Writes error into log and shows error in message dialog
      * <p>

--- a/src/main/java/net/ftb/util/FTBFileUtils.java
+++ b/src/main/java/net/ftb/util/FTBFileUtils.java
@@ -40,6 +40,9 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 public class FTBFileUtils {
+    private FTBFileUtils() {
+    }
+
     /**
      * @param sourceFolder - the folder to be moved
      * @param destinationFolder - where to move to

--- a/src/main/java/net/ftb/util/GameUtils.java
+++ b/src/main/java/net/ftb/util/GameUtils.java
@@ -25,6 +25,9 @@ import javax.swing.*;
 
 public class GameUtils {
 
+    private GameUtils() {
+    }
+
     public static void killMC () {
         //if Mc is running
         if (LaunchFrame.MCRunning) {

--- a/src/main/java/net/ftb/util/NewsUtils.java
+++ b/src/main/java/net/ftb/util/NewsUtils.java
@@ -31,6 +31,9 @@ public class NewsUtils {
     private static List<NewsArticle> news = null;
     private static DateFormat dateFormatterRss = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z");
 
+    private NewsUtils() {
+    }
+
     public static void initializeNews () {
         news = RSSReader.readRSS();
     }

--- a/src/main/java/net/ftb/util/OSUtils.java
+++ b/src/main/java/net/ftb/util/OSUtils.java
@@ -54,6 +54,9 @@ public class OSUtils {
 
     private static UUID clientUUID;
 
+    private OSUtils() {
+    }
+
     public static Proxy getProxy (String url) {
         // this is set explicitly with command line define or by our proxy setting
         String system = System.getProperty("java.net.useSystemProxies");

--- a/src/main/java/net/ftb/util/ObjectUtils.java
+++ b/src/main/java/net/ftb/util/ObjectUtils.java
@@ -22,6 +22,9 @@ import java.util.Arrays;
 
 public class ObjectUtils {
 
+    private ObjectUtils() {
+    }
+
     /**
      *
      * @param s - string to check

--- a/src/main/java/net/ftb/util/SSLUtils.java
+++ b/src/main/java/net/ftb/util/SSLUtils.java
@@ -39,6 +39,9 @@ import java.security.cert.X509Certificate;
 
 public class SSLUtils {
 
+    private SSLUtils() {
+    }
+
     /**
      *
      * @param s host name to test

--- a/src/main/java/net/ftb/util/StyleUtil.java
+++ b/src/main/java/net/ftb/util/StyleUtil.java
@@ -21,6 +21,9 @@ import net.ftb.data.LauncherStyle;
 import javax.swing.*;
 
 public class StyleUtil {
+    private StyleUtil() {
+    }
+
     public static void loadUiStyles () {
         LauncherStyle style = LauncherStyle.getCurrentStyle();
         UIManager.put("control", style.control);

--- a/src/main/java/net/ftb/util/TrackerUtils.java
+++ b/src/main/java/net/ftb/util/TrackerUtils.java
@@ -27,7 +27,7 @@ public class TrackerUtils {
     public static boolean googleEnabled = true;
     public static boolean piwikEnabled = false;
 
-    public TrackerUtils () {
+    private TrackerUtils() {
     }
 
     /**

--- a/src/main/java/net/ftb/util/winreg/JavaFinder.java
+++ b/src/main/java/net/ftb/util/winreg/JavaFinder.java
@@ -21,6 +21,9 @@ import java.util.List;
  * Windows-specific java versions finder
  *****************************************************************************/
 public class JavaFinder {
+    private JavaFinder() {
+    }
+
     /**
      * @return: A list of javaExec paths found under this registry key (rooted at HKEY_LOCAL_MACHINE)
      * @param wow64  0 for standard registry access (32-bits for 32-bit app, 64-bits for 64-bits app)

--- a/src/main/java/net/ftb/workers/AuthlibHelper.java
+++ b/src/main/java/net/ftb/workers/AuthlibHelper.java
@@ -54,6 +54,9 @@ import java.util.Map;
 public class AuthlibHelper {
     private static String uniqueID;
 
+    private AuthlibHelper() {
+    }
+
     protected static LoginResponse authenticateWithAuthlib (String user, String pass, String mojangData, String selectedProfileName) {
         String displayName;
         boolean hasMojangData = false;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.