### PR TITLE
Run xdg-open without checking where it is.

### DIFF
--- a/src/main/java/net/ftb/util/OSUtils.java
+++ b/src/main/java/net/ftb/util/OSUtils.java
@@ -525,7 +525,7 @@ public class OSUtils {
         try {
             if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
                 Desktop.getDesktop().browse(new URI(url.replace(" ", "+")));
-            } else if (getCurrentOS() == OS.UNIX && (new File("/usr/bin/xdg-open").exists() || new File("/usr/local/bin/xdg-open").exists())) {
+            } else if (getCurrentOS() == OS.UNIX) {
                 // Work-around to support non-GNOME Linux desktop environments with xdg-open installed
                 new ProcessBuilder("xdg-open", url).start();
             } else {
@@ -549,9 +549,7 @@ public class OSUtils {
                 Desktop.getDesktop().open(path);
             } else if (getCurrentOS() == OS.UNIX) {
                 // Work-around to support non-GNOME Linux desktop environments with xdg-open installed
-                if (new File("/usr/bin/xdg-open").exists() || new File("/usr/local/bin/xdg-open").exists()) {
-                    new ProcessBuilder("xdg-open", path.toString()).start();
-                }
+                new ProcessBuilder("xdg-open", path.toString()).start();
             }
         } catch (Exception e) {
             Logger.logError("Could not open file", e);


### PR DESCRIPTION
Fixes #981. In case it doesn't exist, there'll be a different exception printed;
nothing else changes.