### PR TITLE
Print URL in log when attempting to open a URL in an external web browser fails

### DIFF
--- a/src/main/java/net/ftb/util/OSUtils.java
+++ b/src/main/java/net/ftb/util/OSUtils.java
@@ -529,7 +529,7 @@ public class OSUtils {
                 // Work-around to support non-GNOME Linux desktop environments with xdg-open installed
                 new ProcessBuilder("xdg-open", url).start();
             } else {
-                Logger.logWarn("Could not open Java Download url, not supported");
+                Logger.logWarn("Could not open Java Download url in web browser: " + url);
             }
         } catch (Exception e) {
             Logger.logError("Could not open link: " + url, e);


### PR DESCRIPTION
In the case where all of the attempts to start an external web browser fail,
this change will cause the URL to be printed in the console, so the user can
copy and paste it manually.